### PR TITLE
Implement portfolio models and portfolio summary API

### DIFF
--- a/backend/routes/portfolio_routes.py
+++ b/backend/routes/portfolio_routes.py
@@ -1,27 +1,212 @@
-from flask import Blueprint, jsonify
 import logging
+from flask import Blueprint, jsonify, request
+from sqlalchemy.sql import func
+
+from backend.models import (
+    db,
+    Portfolio,
+    PortfolioPosition,
+    AssetMetrics,
+    PortfolioDailyValue,
+)
 
 logger = logging.getLogger(__name__)
-portfolio_bp = Blueprint('portfolio_bp', __name__)
+portfolio_bp = Blueprint("portfolio_bp", __name__)
 
-# --- ATENÇÃO: ESTA ROTA USA DADOS MOCK (SIMULADOS) ---
-# Uma implementação real exigiria modelos de dados para Usuário, Portfólio,
-# e Posições (Holdings), além de um sistema de autenticação.
 
-@portfolio_bp.route('/summary', methods=['GET'])
-def get_portfolio_summary():
-    """Retorna um resumo de um portfólio de exemplo."""
+def calculate_portfolio_summary(portfolio_id: int):
+    """Calcula o resumo e holdings do portfólio."""
+    portfolio = Portfolio.query.get(portfolio_id)
+    if not portfolio:
+        return None
+
+    positions = (
+        PortfolioPosition.query.filter_by(portfolio_id=portfolio_id)
+        .join(
+            AssetMetrics,
+            PortfolioPosition.symbol == AssetMetrics.symbol,
+            isouter=True,
+        )
+        .all()
+    )
+
+    holdings = []
+    total_value = 0.0
+    total_cost = 0.0
+    for pos in positions:
+        current_price = float(pos.metrics.last_price) if pos.metrics else 0.0
+        quantity = float(pos.quantity)
+        avg_price = float(pos.avg_price)
+        value = quantity * current_price
+        cost = quantity * avg_price
+        gain = value - cost
+        gain_percent = (gain / cost * 100) if cost else 0.0
+
+        holdings.append(
+            {
+                "symbol": pos.symbol,
+                "quantity": quantity,
+                "avg_price": avg_price,
+                "current_price": current_price,
+                "value": value,
+                "cost": cost,
+                "gain": gain,
+                "gain_percent": gain_percent,
+            }
+        )
+
+        total_value += value
+        total_cost += cost
+
+    total_gain = total_value - total_cost
+    total_gain_percent = (total_gain / total_cost * 100) if total_cost else 0.0
+
+    summary = {
+        "id": portfolio.id,
+        "name": portfolio.name,
+        "total_value": total_value,
+        "total_cost": total_cost,
+        "total_gain": total_gain,
+        "total_gain_percent": total_gain_percent,
+        "holdings": holdings,
+    }
+    return summary
+
+
+@portfolio_bp.route("/<int:portfolio_id>/summary", methods=["GET"])
+def get_portfolio_summary(portfolio_id: int):
+    """Retorna holdings e resumo de um portfólio."""
     try:
-        mock_portfolio = {
-            "id": 1, "name": "Carteira Principal", "total_value": 52850.75,
-            "total_gain_loss_percent": 2.15,
-            "holdings": [
-                {"ticker": "VALE3", "quantity": 100, "avg_price": 50.50, "total_value": 6120.50},
-                {"ticker": "PETR4", "quantity": 200, "avg_price": 38.00, "total_value": 7800.20},
-                {"ticker": "ITUB4", "quantity": 300, "avg_price": 31.00, "total_value": 9900.00},
-            ]
-        }
-        return jsonify({"success": True, "portfolio": mock_portfolio})
+        summary = calculate_portfolio_summary(portfolio_id)
+        if not summary:
+            return (
+                jsonify({"success": False, "error": "Portfólio não encontrado"}),
+                404,
+            )
+
+        return jsonify({"success": True, "portfolio": summary})
     except Exception as e:
         logger.error(f"Erro em get_portfolio_summary: {e}")
-        return jsonify({"success": False, "error": "Erro interno ao buscar portfólio"}), 500
+        return (
+            jsonify({"success": False, "error": "Erro interno ao buscar portfólio"}),
+            500,
+        )
+
+
+@portfolio_bp.route("/<int:portfolio_id>/positions", methods=["POST"])
+def upsert_positions(portfolio_id: int):
+    """Insere ou atualiza posições de um portfólio."""
+    data = request.get_json(silent=True) or []
+    if not isinstance(data, list):
+        return jsonify({"success": False, "error": "Formato inválido"}), 400
+
+    try:
+        portfolio = Portfolio.query.get(portfolio_id)
+        if not portfolio:
+            portfolio = Portfolio(id=portfolio_id, name=f"Portfolio {portfolio_id}")
+            db.session.add(portfolio)
+
+        for item in data:
+            symbol = item.get("symbol")
+            quantity = item.get("quantity", 0)
+            avg_price = item.get("avg_price", 0)
+            if not symbol:
+                continue
+
+            position = PortfolioPosition.query.filter_by(
+                portfolio_id=portfolio_id, symbol=symbol
+            ).first()
+            if position:
+                position.quantity = quantity
+                position.avg_price = avg_price
+            else:
+                db.session.add(
+                    PortfolioPosition(
+                        portfolio=portfolio,
+                        symbol=symbol,
+                        quantity=quantity,
+                        avg_price=avg_price,
+                    )
+                )
+
+        db.session.commit()
+        return jsonify({"success": True}), 201
+    except Exception as e:
+        db.session.rollback()
+        logger.error(f"Erro ao inserir posições: {e}")
+        return (
+            jsonify({"success": False, "error": "Erro ao inserir posições"}),
+            500,
+        )
+
+
+@portfolio_bp.route("/<int:portfolio_id>/snapshot", methods=["POST"])
+def create_portfolio_snapshot(portfolio_id: int):
+    """Salva um snapshot diário do valor do portfólio."""
+    try:
+        summary = calculate_portfolio_summary(portfolio_id)
+        if not summary:
+            return (
+                jsonify({"success": False, "error": "Portfólio não encontrado"}),
+                404,
+            )
+
+        record = PortfolioDailyValue.query.filter_by(
+            portfolio_id=portfolio_id, date=func.current_date()
+        ).first()
+
+        if record:
+            record.total_value = summary["total_value"]
+            record.total_cost = summary["total_cost"]
+            record.total_gain = summary["total_gain"]
+            record.total_gain_percent = summary["total_gain_percent"]
+        else:
+            db.session.add(
+                PortfolioDailyValue(
+                    portfolio_id=portfolio_id,
+                    total_value=summary["total_value"],
+                    total_cost=summary["total_cost"],
+                    total_gain=summary["total_gain"],
+                    total_gain_percent=summary["total_gain_percent"],
+                )
+            )
+
+        db.session.commit()
+        return jsonify({"success": True}), 201
+    except Exception as e:
+        db.session.rollback()
+        logger.error(f"Erro ao salvar snapshot: {e}")
+        return (
+            jsonify({"success": False, "error": "Erro ao salvar snapshot"}),
+            500,
+        )
+
+
+@portfolio_bp.route("/<int:portfolio_id>/daily-values", methods=["GET"])
+def get_portfolio_daily_values(portfolio_id: int):
+    """Retorna a série de valores diários do portfólio."""
+    try:
+        values = (
+            PortfolioDailyValue.query.filter_by(portfolio_id=portfolio_id)
+            .order_by(PortfolioDailyValue.date)
+            .all()
+        )
+
+        result = [
+            {
+                "date": v.date.isoformat(),
+                "total_value": float(v.total_value),
+                "total_cost": float(v.total_cost),
+                "total_gain": float(v.total_gain),
+                "total_gain_percent": float(v.total_gain_percent),
+            }
+            for v in values
+        ]
+
+        return jsonify({"success": True, "values": result})
+    except Exception as e:
+        logger.error(f"Erro ao buscar histórico: {e}")
+        return (
+            jsonify({"success": False, "error": "Erro ao buscar histórico"}),
+            500,
+        )

--- a/frontend/components/PortfolioDashboard.tsx
+++ b/frontend/components/PortfolioDashboard.tsx
@@ -1,253 +1,85 @@
-import React from 'react';
-import { LineChart, Line, BarChart, Bar, XAxis, YAxis, Tooltip, Legend, ResponsiveContainer, Cell } from 'recharts';
-import { Asset, PortfolioSummary, SuggestedPortfolioAsset, SectorWeight } from '../types';
+import React, { useEffect, useState } from 'react';
 import PortfolioManager from './PortfolioManager';
-
-const mockAssets: Asset[] = [
-  { ticker: 'PROJ3', price: 42.88, dailyChange: 0.47, contribution: 0.02, quantity: 26000, positionValue: 1118310.40, positionPercent: 10.70, targetPercent: 15.00, difference: -4.30, adjustment: 20463 },
-  { ticker: 'RAPT4', price: 7.46, dailyChange: 1.63, contribution: 0.12, quantity: 100000, positionValue: 746000.00, positionPercent: 7.14, targetPercent: 11.00, difference: -3.86, adjustment: 54123 },
-  { ticker: 'MDNE3', price: 11.21, dailyChange: 3.06, contribution: 0.29, quantity: 47400, positionValue: 1855154.00, positionPercent: 9.62, targetPercent: 9.00, difference: 0.62, adjustment: -3046 },
-  { ticker: 'ANIM3', price: 3.65, dailyChange: 2.24, contribution: 0.08, quantity: 110100, positionValue: 401865.00, positionPercent: 3.84, targetPercent: 7.00, difference: -3.16, adjustment: 90354 },
-  { ticker: 'SINK3', price: 4.19, dailyChange: 1.45, contribution: 0.05, quantity: 85500, positionValue: 358245.00, positionPercent: 3.43, targetPercent: 7.00, difference: -3.57, adjustment: 89120 },
-];
-
-const mockSummary: PortfolioSummary = {
-  netLiquidity: 10452249.17,
-  quoteValue: 118.3171,
-  dailyChange: -0.59,
-  buyPosition: 87.16,
-  sellPosition: 16.83,
-  netLong: 56.36,
-  exposure: 84.82,
-};
-
-const contributionData = mockAssets.map(a => ({ name: a.ticker, value: a.adjustment })).sort((a,b) => b.value - a.value);
-const returnData = Array.from({ length: 12 }, (_, i) => ({
-  name: `Jan 202${i < 10 ? '3' : '4'}`,
-  'Retorno da Cota': 100 + Math.random() * 50 * Math.sin(i),
-  'Retorno do Ibovespa': 100 + Math.random() * 40 * Math.sin(i * 0.8),
-}));
-
-const suggestedPortfolioData: SuggestedPortfolioAsset[] = [
-    { ticker: 'BPAC11', company: 'BTG Pactual', currency: 'BRL', currentPrice: 40.8, targetPrice: 47.0, upsideDownside: 15, mktCap: 189469, pe26: 9.3, pe5yAvg: 11.5, deltaPe: -19, evEbitda26: 'NM', evEbitda5yAvg: 'NM', deltaEvEbitda: 'NM', epsGrowth26: 15, ibovWeight: 2.5, portfolioWeight: 8.0, owUw: 5.5 },
-    { ticker: 'MOTV3', company: 'Motiva', currency: 'BRL', currentPrice: 13.2, targetPrice: 16.8, upsideDownside: 27, mktCap: 26664, pe26: 11.8, pe5yAvg: 16.0, deltaPe: -26, evEbitda26: 5.8, evEbitda5yAvg: 6.2, deltaEvEbitda: -6, epsGrowth26: 26, ibovWeight: 0.6, portfolioWeight: 6.0, owUw: 5.4 },
-    { ticker: 'LREN3', company: 'Lojas Renner', currency: 'BRL', currentPrice: 19.2, targetPrice: 24.3, upsideDownside: 27, mktCap: 20301, pe26: 11.6, pe5yAvg: 16.1, deltaPe: -28, evEbitda26: 6.8, evEbitda5yAvg: 8.5, deltaEvEbitda: -20, epsGrowth26: 12, ibovWeight: 0.9, portfolioWeight: 6.0, owUw: 5.1 },
-    { ticker: 'SMFT3', company: 'SmartFit', currency: 'BRL', currentPrice: 22.7, targetPrice: 30.0, upsideDownside: 32, mktCap: 13575, pe26: 15.2, pe5yAvg: 54.2, deltaPe: -72, evEbitda26: 8.7, evEbitda5yAvg: 'NM', deltaEvEbitda: 'NM', epsGrowth26: 'NM', ibovWeight: 1.5, portfolioWeight: 6.0, owUw: 4.5 },
-    { ticker: 'INBR32', company: 'Inter', currency: 'BRL', currentPrice: 38.2, targetPrice: 52.0, upsideDownside: 36, mktCap: 16784, pe26: 'NM', pe5yAvg: 'NM', deltaPe: 'NM', evEbitda26: 'NM', evEbitda5yAvg: 'NM', deltaEvEbitda: 'NM', epsGrowth26: 'NM', ibovWeight: 1.5, portfolioWeight: 6.0, owUw: 4.5 },
-    { ticker: 'RDOR3', company: 'Rede D\'Or', currency: 'BRL', currentPrice: 33.8, targetPrice: 34.5, upsideDownside: 2, mktCap: 77401, pe26: 13.8, pe5yAvg: 24.5, deltaPe: -44, evEbitda26: 7.4, evEbitda5yAvg: 12.1, deltaEvEbitda: -39, epsGrowth26: 24, ibovWeight: 1.9, portfolioWeight: 6.0, owUw: 4.1 },
-    { ticker: 'ITSA4', company: 'Itausa', currency: 'BRL', currentPrice: 10.6, targetPrice: 12.0, upsideDownside: 14, mktCap: 116174, pe26: 6.2, pe5yAvg: 6.8, deltaPe: -10, evEbitda26: 'NM', evEbitda5yAvg: 'NM', deltaEvEbitda: 'NM', epsGrowth26: 11, ibovWeight: 11.3, portfolioWeight: 11.0, owUw: -0.3 },
-    { ticker: 'VALE3', company: 'Vale', currency: 'BRL', currentPrice: 55.3, targetPrice: 75.0, upsideDownside: 36, mktCap: 250916, pe26: 5.5, pe5yAvg: 5.6, deltaPe: -2, evEbitda26: 3.9, evEbitda5yAvg: 3.6, deltaEvEbitda: 8, epsGrowth26: 3, ibovWeight: 11.2, portfolioWeight: 9.0, owUw: -2.2 },
-];
-
-const sectorWeightsData: SectorWeight[] = [
-    { sector: 'Retail', ibovWeight: 3.9, portfolioWeight: 15.0, owUw: 11.1 },
-    { sector: 'Real Estate', ibovWeight: 0.6, portfolioWeight: 8.0, owUw: 7.4 },
-    { sector: 'Financials - Banks', ibovWeight: 21.6, portfolioWeight: 25.0, owUw: 3.4 },
-    { sector: 'Healthcare', ibovWeight: 3.1, portfolioWeight: 6.0, owUw: 2.9 },
-    { sector: 'Oil & Gas', ibovWeight: 15.8, portfolioWeight: 13.0, owUw: -2.8 },
-    { sector: 'Utilities', ibovWeight: 15.2, portfolioWeight: 11.0, owUw: -4.2 },
-    { sector: 'Metals & Mining', ibovWeight: 13.3, portfolioWeight: 9.0, owUw: -4.3 },
-    { sector: 'Financials - Others', ibovWeight: 5.8, portfolioWeight: 0.0, owUw: -5.8 },
-];
-
-
-const OwUwBar: React.FC<{ value: number }> = ({ value }) => {
-    const maxValue = Math.max(...sectorWeightsData.map(d => Math.abs(d.owUw)));
-    const percentage = (Math.abs(value) / maxValue) * 50;
-    const isOverweight = value > 0;
-
-    return (
-        <div className="w-full h-full relative bg-slate-700 rounded-sm">
-            <div
-                className={`absolute h-full ${isOverweight ? 'bg-sky-500' : 'bg-red-500'} rounded-sm`}
-                style={{
-                    width: `${percentage}%`,
-                    left: isOverweight ? '50%' : `${50 - percentage}%`,
-                }}
-            ></div>
-            <div className="absolute w-full h-full text-center text-xs font-semibold text-white z-10 flex items-center justify-center">
-              {value.toFixed(1)}%
-            </div>
-        </div>
-    );
-};
-
+import { PortfolioSummary } from '../types';
+import { portfolioApi } from '../services/portfolioApi';
 
 const PortfolioDashboard: React.FC = () => {
-    return (
-        <div className="space-y-6">
-            <PortfolioManager initialAssets={mockAssets.map((a,i) => ({id: i, ticker: a.ticker, quantity: a.quantity, targetWeight: a.targetPercent}))}/>
-            
-            <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-                <div className="lg:col-span-2 bg-slate-800/50 rounded-lg p-6 border border-slate-700">
-                    <h2 className="text-xl font-semibold text-white mb-4">Composição da Carteira</h2>
-                    <div className="overflow-x-auto">
-                        <table className="w-full text-sm text-left text-slate-300">
-                            <thead className="text-xs text-slate-400 uppercase bg-slate-700/50">
-                                <tr>
-                                    {['Ativo', 'Cotação', 'Var. Dia (%)', 'Contrib. (%)', 'Quantidade', 'Posição (R$)', 'Posição (%)', 'Posição %-Alvo', 'Diferença', 'Ajuste (Qtd.)'].map(h => 
-                                        <th key={h} scope="col" className="px-4 py-3 whitespace-nowrap">{h}</th>
-                                    )}
-                                </tr>
-                            </thead>
-                            <tbody>
-                                {mockAssets.map((asset) => (
-                                    <tr key={asset.ticker} className="border-b border-slate-700 hover:bg-slate-700/30">
-                                        <td className="px-4 py-3 font-medium text-white whitespace-nowrap">{asset.ticker}</td>
-                                        <td className="px-4 py-3">R$ {asset.price.toFixed(2)}</td>
-                                        <td className={`px-4 py-3 ${asset.dailyChange > 0 ? 'text-green-400' : 'text-red-400'}`}>{asset.dailyChange.toFixed(2)}%</td>
-                                        <td className={`px-4 py-3 ${asset.contribution > 0 ? 'text-green-400' : 'text-red-400'}`}>{asset.contribution.toFixed(2)}%</td>
-                                        <td className="px-4 py-3">{asset.quantity.toLocaleString('pt-BR')}</td>
-                                        <td className="px-4 py-3">R$ {asset.positionValue.toLocaleString('pt-BR', { minimumFractionDigits: 2 })}</td>
-                                        <td className="px-4 py-3">{asset.positionPercent.toFixed(2)}%</td>
-                                        <td className="px-4 py-3">{asset.targetPercent.toFixed(2)}%</td>
-                                        <td className={`px-4 py-3 ${asset.difference > 0 ? 'text-green-400' : 'text-red-400'}`}>{asset.difference.toFixed(2)}%</td>
-                                        <td className={`px-4 py-3 ${asset.adjustment > 0 ? 'text-green-400' : 'text-red-400'}`}>{asset.adjustment.toLocaleString('pt-BR')}</td>
-                                    </tr>
-                                ))}
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
+  const [portfolio, setPortfolio] = useState<PortfolioSummary | null>(null);
+  const [error, setError] = useState<string | null>(null);
 
-                <div className="bg-slate-800/50 rounded-lg p-6 border border-slate-700 h-fit">
-                    <h2 className="text-xl font-semibold text-white mb-4">Resumo do Portfólio</h2>
-                    <div className="space-y-4">
-                        <div>
-                            <p className="text-sm text-slate-400">Patrimônio Líquido</p>
-                            <p className="text-3xl font-bold text-white">R$ {mockSummary.netLiquidity.toLocaleString('pt-BR', { minimumFractionDigits: 2 })}</p>
-                        </div>
-                        <div>
-                            <p className="text-sm text-slate-400">Valor da Cota</p>
-                            <div className="flex items-baseline space-x-2">
-                                <p className="text-2xl font-bold text-white">R$ {mockSummary.quoteValue.toFixed(4)}</p>
-                                <p className={`text-sm font-semibold ${mockSummary.dailyChange > 0 ? 'text-green-400' : 'text-red-400'}`}>
-                                    {mockSummary.dailyChange > 0 ? '▲' : '▼'} {Math.abs(mockSummary.dailyChange)}%
-                                </p>
-                            </div>
-                        </div>
-                        <div className="border-t border-slate-700 pt-4 space-y-2 text-sm">
-                            <div className="flex justify-between"><span className="text-slate-400">Posição Comprada:</span> <span className="font-medium text-white">{mockSummary.buyPosition.toFixed(2)}%</span></div>
-                            <div className="flex justify-between"><span className="text-slate-400">Posição Vendida:</span> <span className="font-medium text-white">{mockSummary.sellPosition.toFixed(2)}%</span></div>
-                            <div className="flex justify-between"><span className="text-slate-400">Net Long:</span> <span className="font-medium text-white">{mockSummary.netLong.toFixed(2)}%</span></div>
-                            <div className="flex justify-between"><span className="text-slate-400">Exposição Total:</span> <span className="font-medium text-white">{mockSummary.exposure.toFixed(2)}%</span></div>
-                        </div>
-                    </div>
-                </div>
+  useEffect(() => {
+    async function load() {
+      try {
+        const data = await portfolioApi.getPortfolioSummary(1);
+        setPortfolio(data);
+      } catch (err) {
+        console.error(err);
+        setError('Erro ao carregar portfólio');
+      }
+    }
+    load();
+  }, []);
+
+  const holdings = portfolio?.holdings ?? [];
+
+  return (
+    <div className="space-y-6">
+      <PortfolioManager
+        initialAssets={holdings.map((h, i) => ({
+          id: i,
+          ticker: h.symbol,
+          quantity: h.quantity,
+          targetWeight: 0,
+        }))}
+      />
+
+      {error && <p className="text-red-400">{error}</p>}
+
+      {portfolio && (
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+          <div className="lg:col-span-2 bg-slate-800/50 rounded-lg p-6 border border-slate-700">
+            <h2 className="text-xl font-semibold text-white mb-4">Composição da Carteira</h2>
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm text-left text-slate-300">
+                <thead className="text-xs text-slate-400 uppercase bg-slate-700/50">
+                  <tr>
+                    {['Ativo','Qtd','Preço Médio','Preço Atual','Valor','P/L','P/L%'].map(h => (
+                      <th key={h} className="px-4 py-3 whitespace-nowrap">{h}</th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {holdings.map(h => (
+                    <tr key={h.symbol} className="border-b border-slate-700 hover:bg-slate-700/30">
+                      <td className="px-4 py-3 font-medium text-white whitespace-nowrap">{h.symbol}</td>
+                      <td className="px-4 py-3">{h.quantity}</td>
+                      <td className="px-4 py-3">R$ {h.avg_price.toFixed(2)}</td>
+                      <td className="px-4 py-3">R$ {h.current_price.toFixed(2)}</td>
+                      <td className="px-4 py-3">R$ {h.value.toFixed(2)}</td>
+                      <td className={`px-4 py-3 ${h.gain >= 0 ? 'text-green-400' : 'text-red-400'}`}>R$ {h.gain.toFixed(2)}</td>
+                      <td className={`px-4 py-3 ${h.gain >= 0 ? 'text-green-400' : 'text-red-400'}`}>{h.gain_percent.toFixed(2)}%</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
             </div>
-
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-                <div className="bg-slate-800/50 rounded-lg p-6 border border-slate-700">
-                    <h3 className="text-lg font-semibold text-white mb-4">Contribuição para Variação Diária</h3>
-                    <ResponsiveContainer width="100%" height={300}>
-                        <BarChart data={contributionData} margin={{ top: 5, right: 20, left: -10, bottom: 5 }}>
-                            <XAxis dataKey="name" stroke="#94a3b8" fontSize={12} tickLine={false} axisLine={false} />
-                            <YAxis stroke="#94a3b8" fontSize={12} tickLine={false} axisLine={false} tickFormatter={(value) => `${(Number(value)/1000)}k`} />
-                            <Tooltip
-                                contentStyle={{ backgroundColor: '#1e293b', border: '1px solid #334155', color: '#cbd5e1' }}
-                                cursor={{ fill: 'rgba(148, 163, 184, 0.1)' }}
-                            />
-                            <Bar dataKey="value">
-                                {contributionData.map((entry, index) => (
-                                    <Cell key={`cell-${index}`} fill={entry.value > 0 ? '#4ade80' : '#f87171'} />
-                                ))}
-                            </Bar>
-                        </BarChart>
-                    </ResponsiveContainer>
-                </div>
-                <div className="bg-slate-800/50 rounded-lg p-6 border border-slate-700">
-                    <h3 className="text-lg font-semibold text-white mb-4">Retorno Acumulado: Cota vs. Ibovespa</h3>
-                    <ResponsiveContainer width="100%" height={300}>
-                        <LineChart data={returnData} margin={{ top: 5, right: 20, left: -10, bottom: 5 }}>
-                            <XAxis dataKey="name" stroke="#94a3b8" fontSize={12} tickLine={false} axisLine={false} />
-                            <YAxis stroke="#94a3b8" fontSize={12} tickLine={false} axisLine={false} />
-                            <Tooltip
-                                contentStyle={{ backgroundColor: '#1e293b', border: '1px solid #334155', color: '#cbd5e1' }}
-                            />
-                            <Legend wrapperStyle={{fontSize: "14px"}}/>
-                            <Line type="monotone" dataKey="Retorno da Cota" stroke="#38bdf8" strokeWidth={2} dot={false} />
-                            <Line type="monotone" dataKey="Retorno do Ibovespa" stroke="#a78bfa" strokeWidth={2} dot={false} />
-                        </LineChart>
-                    </ResponsiveContainer>
-                </div>
+          </div>
+          <div className="bg-slate-800/50 rounded-lg p-6 border border-slate-700 h-fit">
+            <h2 className="text-xl font-semibold text-white mb-4">Resumo do Portfólio</h2>
+            <div className="space-y-2 text-sm">
+              <div className="flex justify-between"><span className="text-slate-400">Valor Total:</span><span className="font-medium text-white">R$ {portfolio.total_value.toFixed(2)}</span></div>
+              <div className="flex justify-between"><span className="text-slate-400">Custo Total:</span><span className="font-medium text-white">R$ {portfolio.total_cost.toFixed(2)}</span></div>
+              <div className={`flex justify-between ${portfolio.total_gain >= 0 ? 'text-green-400' : 'text-red-400'}`}>
+                <span>Ganho/Perda:</span>
+                <span>R$ {portfolio.total_gain.toFixed(2)} ({portfolio.total_gain_percent.toFixed(2)}%)</span>
+              </div>
             </div>
-
-            <div className="space-y-6">
-                <div className="bg-slate-800/50 rounded-lg p-6 border border-slate-700">
-                    <h3 className="text-lg font-semibold text-white mb-2">Carteira Sugerida</h3>
-                    <p className="text-xs text-slate-400 mb-4">Fonte: Santander Estimates, Bloomberg. Atualizado em 10 de julho de 2025.</p>
-                     <div className="overflow-x-auto">
-                        <table className="w-full text-sm text-left text-slate-300">
-                            <thead className="text-xs text-slate-400 uppercase bg-slate-700/50">
-                                <tr>
-                                    {['Ticker', 'Company', 'Currency', 'Current Price', 'Target Price', 'Upside/Downside', 'Mkt Cap (Million)', 'P/E 26', 'P/E 5Y AVG', 'Delta P/E', 'EV/Ebitda 26', 'EV/Ebitda 5Y AVG', 'Delta EV/Ebitda', 'EPS growth 26', 'IBOV Weight', 'Portfolio weight', 'OW/UW'].map(h => 
-                                        <th key={h} scope="col" className="px-3 py-3 font-medium whitespace-nowrap">{h}</th>
-                                    )}
-                                </tr>
-                            </thead>
-                            <tbody>
-                                {suggestedPortfolioData.map((asset) => (
-                                    <tr key={asset.ticker} className="border-b border-slate-700 hover:bg-slate-700/30">
-                                        <td className="px-3 py-2 font-semibold text-white whitespace-nowrap">{asset.ticker}</td>
-                                        <td className="px-3 py-2 whitespace-nowrap">{asset.company}</td>
-                                        <td className="px-3 py-2">{asset.currency}</td>
-                                        <td className="px-3 py-2">{asset.currentPrice.toFixed(1)}</td>
-                                        <td className="px-3 py-2">{asset.targetPrice.toFixed(1)}</td>
-                                        <td className={`px-3 py-2 ${asset.upsideDownside > 0 ? 'text-green-400' : 'text-red-400'}`}>{asset.upsideDownside}%</td>
-                                        <td className="px-3 py-2">{asset.mktCap.toLocaleString('pt-BR')}</td>
-                                        <td className="px-3 py-2">{asset.pe26}</td>
-                                        <td className="px-3 py-2">{asset.pe5yAvg}</td>
-                                        <td className={`px-3 py-2 ${typeof asset.deltaPe === 'number' && asset.deltaPe > 0 ? 'text-green-400' : 'text-red-400'}`}>{typeof asset.deltaPe === 'number' ? `${asset.deltaPe}%` : asset.deltaPe}</td>
-                                        <td className="px-3 py-2">{asset.evEbitda26}</td>
-                                        <td className="px-3 py-2">{asset.evEbitda5yAvg}</td>
-                                        <td className={`px-3 py-2 ${typeof asset.deltaEvEbitda === 'number' && asset.deltaEvEbitda > 0 ? 'text-green-400' : 'text-red-400'}`}>{typeof asset.deltaEvEbitda === 'number' ? `${asset.deltaEvEbitda}%` : asset.deltaEvEbitda}</td>
-                                        <td className={`px-3 py-2 ${typeof asset.epsGrowth26 === 'number' && asset.epsGrowth26 > 0 ? 'text-green-400' : 'text-red-400'}`}>{typeof asset.epsGrowth26 === 'number' ? `${asset.epsGrowth26}%` : asset.epsGrowth26}</td>
-                                        <td className="px-3 py-2">{asset.ibovWeight.toFixed(1)}%</td>
-                                        <td className="px-3 py-2">{asset.portfolioWeight.toFixed(1)}%</td>
-                                        <td className={`px-3 py-2 font-bold ${asset.owUw > 0 ? 'text-sky-400' : 'text-orange-400'}`}>
-                                            <div className={`p-1 rounded text-center ${asset.owUw > 0 ? 'bg-sky-500/20' : 'bg-orange-500/20'}`}>
-                                                {asset.owUw.toFixed(1)}%
-                                            </div>
-                                        </td>
-                                    </tr>
-                                ))}
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
-
-                <div className="bg-slate-800/50 rounded-lg p-6 border border-slate-700">
-                    <h3 className="text-lg font-semibold text-white mb-2">Pesos por Setor</h3>
-                     <p className="text-xs text-slate-400 mb-4">Para mais detalhes, veja Equity Strategy Insights: Updating Brazil Recommended Portfolio, publicado em 29 de junho de 2025.</p>
-                    <div className="overflow-x-auto">
-                        <table className="w-full text-sm text-left text-slate-300">
-                            <thead className="text-xs text-slate-400 uppercase bg-slate-700/50">
-                                <tr>
-                                    <th className="px-3 py-3 font-medium whitespace-nowrap">Sector</th>
-                                    <th className="px-3 py-3 font-medium whitespace-nowrap">Ibov Weight</th>
-                                    <th className="px-3 py-3 font-medium whitespace-nowrap">Portfolio Weight</th>
-                                    <th className="px-3 py-3 font-medium whitespace-nowrap w-40">OW/UW</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                {sectorWeightsData.map((item) => (
-                                    <tr key={item.sector} className="border-b border-slate-700 hover:bg-slate-700/30">
-                                        <td className="px-3 py-2.5 font-semibold text-white whitespace-nowrap">{item.sector}</td>
-                                        <td className="px-3 py-2.5 whitespace-nowrap">{item.ibovWeight.toFixed(1)}%</td>
-                                        <td className="px-3 py-2.5 whitespace-nowrap">{item.portfolioWeight.toFixed(1)}%</td>
-                                        <td className="px-3 py-2.5">
-                                            <OwUwBar value={item.owUw} />
-                                        </td>
-                                    </tr>
-                                ))}
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
-            </div>
-
+          </div>
         </div>
-    );
+      )}
+    </div>
+  );
 };
 
 export default PortfolioDashboard;
+

--- a/frontend/components/PortfolioManager.tsx
+++ b/frontend/components/PortfolioManager.tsx
@@ -1,9 +1,9 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { EditableAsset, DailyMetric } from '../types';
 import { ChevronUpIcon, PencilSquareIcon, TrashIcon, PlusIcon } from '../constants';
 
 interface PortfolioManagerProps {
-    initialAssets: EditableAsset[];
+    initialAssets?: EditableAsset[];
 }
 
 const initialMetrics: DailyMetric[] = [
@@ -14,10 +14,14 @@ const initialMetrics: DailyMetric[] = [
     { id: 'outrasDespesas', label: 'Outras Despesas', value: 0.00 },
 ];
 
-const PortfolioManager: React.FC<PortfolioManagerProps> = ({ initialAssets }) => {
+const PortfolioManager: React.FC<PortfolioManagerProps> = ({ initialAssets = [] }) => {
     const [isOpen, setIsOpen] = useState(false);
     const [assets, setAssets] = useState<EditableAsset[]>(initialAssets);
     const [metrics, setMetrics] = useState<DailyMetric[]>(initialMetrics);
+
+    useEffect(() => {
+        setAssets(initialAssets);
+    }, [initialAssets]);
 
     const handleAssetChange = (id: number, field: keyof EditableAsset, value: string | number) => {
         setAssets(assets.map(asset => asset.id === id ? { ...asset, [field]: value } : asset));

--- a/frontend/services/portfolioApi.ts
+++ b/frontend/services/portfolioApi.ts
@@ -1,0 +1,34 @@
+import { PortfolioSummary, PortfolioDailyValue } from '../types';
+
+const API_BASE = import.meta.env.VITE_BACKEND_URL || 'http://localhost:5001/api';
+
+export async function getPortfolioSummary(id: number): Promise<PortfolioSummary> {
+  const res = await fetch(`${API_BASE}/portfolio/${id}/summary`);
+  if (!res.ok) {
+    throw new Error('Falha ao buscar portfólio');
+  }
+  const data = await res.json();
+  return data.portfolio as PortfolioSummary;
+}
+
+export async function savePortfolioSnapshot(id: number): Promise<void> {
+  const res = await fetch(`${API_BASE}/portfolio/${id}/snapshot`, { method: 'POST' });
+  if (!res.ok) {
+    throw new Error('Falha ao salvar snapshot');
+  }
+}
+
+export async function getPortfolioDailyValues(id: number): Promise<PortfolioDailyValue[]> {
+  const res = await fetch(`${API_BASE}/portfolio/${id}/daily-values`);
+  if (!res.ok) {
+    throw new Error('Falha ao buscar histórico do portfólio');
+  }
+  const data = await res.json();
+  return data.values as PortfolioDailyValue[];
+}
+export const portfolioApi = {
+  getPortfolioSummary,
+  savePortfolioSnapshot,
+  getPortfolioDailyValues,
+};
+

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -32,13 +32,32 @@ export interface Asset {
 }
 
 export interface PortfolioSummary {
-  netLiquidity: number;
-  quoteValue: number;
-  dailyChange: number;
-  buyPosition: number;
-  sellPosition: number;
-  netLong: number;
-  exposure: number;
+  id: number;
+  name: string;
+  total_value: number;
+  total_cost: number;
+  total_gain: number;
+  total_gain_percent: number;
+  holdings: PortfolioHolding[];
+}
+
+export interface PortfolioDailyValue {
+  date: string;
+  total_value: number;
+  total_cost: number;
+  total_gain: number;
+  total_gain_percent: number;
+}
+
+export interface PortfolioHolding {
+  symbol: string;
+  quantity: number;
+  avg_price: number;
+  current_price: number;
+  value: number;
+  cost: number;
+  gain: number;
+  gain_percent: number;
 }
 
 export interface ChatMessage {


### PR DESCRIPTION
## Summary
- add PortfolioDailyValue model and link it to portfolios
- expose endpoints to record portfolio snapshots and list daily values
- extend frontend types and service with snapshot helpers

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'playwright')*
- `cd frontend && npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6895f37c16a4832793f1629eeaff8b59