### PR TITLE
chore: expand requirements for full dashboard

### DIFF
--- a/INSTRUCOES_EXECUCAO_FINAL.md
+++ b/INSTRUCOES_EXECUCAO_FINAL.md
@@ -10,27 +10,32 @@
 
 ### **2. Instalar Dependências**
 ```bash
-# Backend
-cd backend
+# Backend (Python)
 pip install -r requirements.txt
+playwright install
 
-# Frontend  
+# Frontend (Node)
 cd frontend
 npm install
+cd ..
 ```
 
-### **3. Executar Sistema**
+### **3. Executar Testes (opcional)**
+```bash
+pytest -q
+```
+
+### **4. Executar Sistema**
 ```bash
 # Terminal 1 - Backend
-cd backend
 python run_backend.py
 
 # Terminal 2 - Frontend
-cd frontend  
+cd frontend
 npm start
 ```
 
-### **4. Acessar Dashboard**
+### **5. Acessar Dashboard**
 - **Frontend:** http://localhost:3000
 - **APIs:** http://localhost:5001/api
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,32 +1,44 @@
+# Dependências para o backend e testes do Finance Dashboard
+
 # Flask e extensões
-Flask>=3.1.1
-Flask-SQLAlchemy>=3.1.1
-Flask-Cors>=4.0.1
-Flask-Limiter>=3.5.1
-Flask-SocketIO>=5.3.6
-Flask-JWT-Extended>=4.6.0
+Flask>=3.0
+Flask-SQLAlchemy>=3.0
+Flask-Cors>=4.0
+Flask-Limiter>=3.5
+Flask-SocketIO>=5.3
+Flask-JWT-Extended>=4.5
+python-socketio>=5.8
 
 # Banco de Dados e ORM
-SQLAlchemy>=2.0.28
-psycopg2-binary>=2.9.9
+SQLAlchemy>=2.0
+psycopg2-binary>=2.9
 
 # Coleta e Processamento de Dados
-requests>=2.31.0
-pandas>=2.2.0
-beautifulsoup4>=4.12.3
-trafilatura>=1.9.0
+requests>=2.31
+pandas>=2.2
+numpy>=1.26
+beautifulsoup4>=4.12
+trafilatura>=1.9
+tqdm>=4.66
+yfinance>=0.2
+MetaTrader5>=5.0; platform_system == "Windows"
+playwright>=1.42
 
 # Análise de Sentimento e NLP
-textblob>=0.18.0.post0
+textblob>=0.18
+
+# IA e Serviços Externos
+google-generativeai>=0.4
 
 # Servidor e Utilitários
-gunicorn>=22.0.0
-python-dotenv>=1.0.1
-redis>=5.0.3
-schedule>=1.2.1
+gunicorn>=22
+python-dotenv>=1.0
+redis>=5.0
+schedule>=1.2
+email-validator>=2.1
+Werkzeug>=3.0
+PyJWT>=2.8  # Dependência do Flask-JWT-Extended
 
-# Outros
-email-validator>=2.1.1
-numpy>=1.26.4
-Werkzeug>=3.0.1
-PyJWT>=2.8.0 # Dependência do Flask-JWT-Extended
+# Testes
+pytest>=8.0
+


### PR DESCRIPTION
## Summary
- rewrite requirements.txt consolidating backend, MT5, AI, and test dependencies
- relax dependency versions and add Playwright install instructions
- skip MetaTrader5 installation on non-Windows platforms

## Testing
- `pip install -r requirements.txt`
- `playwright install` *(fails: Error: Download failed: server returned code 403 body 'Domain forbidden')*
- `DB_HOST=localhost DB_PORT=5432 DB_NAME=test DB_USER=test DB_PASSWORD=test pytest -q` *(fails: fixture 'method' not found in test_404.py and test_all_routes.py)*

------
https://chatgpt.com/codex/tasks/task_e_6896008224ec832786e41dfd3d8d8d12