### PR TITLE
feat: handle cvm document loading errors

### DIFF
--- a/frontend/services/cvmService.test.ts
+++ b/frontend/services/cvmService.test.ts
@@ -17,6 +17,11 @@ describe('cvmService', () => {
     expect(companies).toEqual(mockCompanies);
   });
 
+  it('getCompanies lança erro quando resposta não ok', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false }));
+    await expect(cvmService.getCompanies()).rejects.toThrow('Erro ao buscar empresas');
+  });
+
   it('getDocumentTypes retorna lista de categorias', async () => {
     const mockTypes = [{ code: 'CAT', description: 'Categoria' }];
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
@@ -25,6 +30,11 @@ describe('cvmService', () => {
     }));
     const types = await cvmService.getDocumentTypes();
     expect(types).toEqual(mockTypes);
+  });
+
+  it('getDocumentTypes lança erro quando resposta não ok', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false }));
+    await expect(cvmService.getDocumentTypes()).rejects.toThrow('Erro ao buscar tipos de documento');
   });
 
   it('getDocuments usa endpoint por empresa quando companyId informado', async () => {
@@ -54,5 +64,10 @@ describe('cvmService', () => {
       subject: 'Title',
       link: 'http://exemplo'
     });
+  });
+
+  it('getDocuments lança erro quando resposta não ok', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false }));
+    await expect(cvmService.getDocuments()).rejects.toThrow('Erro ao buscar documentos');
   });
 });


### PR DESCRIPTION
## Summary
- add loading and error states to CVM documents component
- show spinner while documents load and friendly error messages on failure
- cover cvmService error scenarios with unit tests

## Testing
- `cd frontend && npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_6896279419208327b10c8f795845797f