### PR TITLE
chore: handle engine creation errors

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -1,8 +1,12 @@
 # backend/config.py
+import logging
 import os
-from dotenv import load_dotenv
 
-load_dotenv() # Carrega variáveis do arquivo .env
+from dotenv import load_dotenv
+from sqlalchemy import create_engine
+
+load_dotenv()  # Carrega variáveis do arquivo .env
+logger = logging.getLogger(__name__)
 
 class Config:
     SECRET_KEY = os.environ.get('SECRET_KEY') or 'uma-chave-secreta-padrao-muito-segura'
@@ -41,5 +45,11 @@ def get_db_engine():
     uri = Config.SQLALCHEMY_DATABASE_URI
     if uri.startswith('sqlite'):
         print("AVISO: get_db_engine está usando o banco de dados em memória (SQLite) de fallback.")
-    
-    return create_engine(uri, pool_pre_ping=True)
+
+    try:
+        engine = create_engine(uri, pool_pre_ping=True)
+    except Exception as exc:
+        logger.exception("Falha ao criar a engine do banco de dados.")
+        raise
+
+    return engine


### PR DESCRIPTION
## Summary
- import SQLAlchemy's `create_engine` and configure logger
- wrap database engine creation in try/except to log failures

## Testing
- `pytest` *(fails: ValueError: Uma ou mais variáveis de ambiente do banco de dados não foram definidas)*

------
https://chatgpt.com/codex/tasks/task_e_68962fadd63c8327b6100a329ffd7408