### PR TITLE
refactor: require env for MT5 credentials

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,16 @@
+# Variáveis de ambiente do projeto
+
+# Banco de dados PostgreSQL
+DB_USER=
+DB_PASSWORD=
+DB_HOST=
+DB_PORT=5432
+DB_NAME=
+
+# Flask
+SECRET_KEY=
+
+# Configurações MetaTrader5
+MT5_LOGIN=
+MT5_PASSWORD=
+MT5_SERVER=

--- a/backend/services/metatrader5_rtd_worker.py
+++ b/backend/services/metatrader5_rtd_worker.py
@@ -43,10 +43,22 @@ class MetaTrader5RTDWorker:
         self.realtime_symbols: Set[str] = set()  # Símbolos com ticks em tempo real
         self.failed_symbols: Set[str] = set()    # Símbolos que falharam na ativação
 
+        # Carrega variáveis do arquivo .env
+        load_dotenv()
+
         # Configurações do MetaTrader5
-        self.MT5_LOGIN = int(os.getenv("MT5_LOGIN", "5223688"))
-        self.MT5_PASSWORD = os.getenv("MT5_PASSWORD", "Pandora337303$")
-        self.MT5_SERVER = os.getenv("MT5_SERVER", "BancoBTGPactual-PRD")
+        self.MT5_LOGIN = os.getenv("MT5_LOGIN")
+        if not self.MT5_LOGIN:
+            raise ValueError("Variável de ambiente MT5_LOGIN não definida")
+        self.MT5_LOGIN = int(self.MT5_LOGIN)
+
+        self.MT5_PASSWORD = os.getenv("MT5_PASSWORD")
+        if not self.MT5_PASSWORD:
+            raise ValueError("Variável de ambiente MT5_PASSWORD não definida")
+
+        self.MT5_SERVER = os.getenv("MT5_SERVER")
+        if not self.MT5_SERVER:
+            raise ValueError("Variável de ambiente MT5_SERVER não definida")
         
         # Configurações de timing
         self.PAUSE_INTERVAL_SECONDS = 2  # Mais rápido para tempo real


### PR DESCRIPTION
## Summary
- remove default MetaTrader5 credentials
- add explicit errors for missing MT5 environment variables
- document required env vars

## Testing
- `pytest` *(fails: fixture 'method' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68962fcecab08327ac1e2b1b0be6c018