### PR TITLE
chore: run frontend tests from root without watch

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,5 @@ This contains everything you need to run your app locally.
 2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
 3. Run the app:
    `npm run dev`
+4. Na raiz do projeto, execute os testes do frontend (uma única vez, sem modo watch):
+   `npm test`

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "vitest"
+    "test": "vitest run"
   },
   "dependencies": {
     "react": "^19.1.0",

--- a/package.json
+++ b/package.json
@@ -3,5 +3,8 @@
   "private": true,
   "workspaces": [
     "frontend"
-  ]
+  ],
+  "scripts": {
+    "test": "npm test --workspace frontend"
+  }
 }


### PR DESCRIPTION
## Summary
- ensure frontend tests run a single time by using `vitest run`
- document one-off frontend test command in README

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68962781e6c48327bf4b6b2c410a0381