### PR TITLE
chore: add env templates and docs for setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,24 +17,19 @@ npm install
 
 ## Variáveis de Ambiente
 
-### `backend/.env`
-```env
-DB_HOST=cvm-insiders-db.cb2uq8cqs3dn.us-east-2.rds.amazonaws.com
-DB_PORT=5432
-DB_NAME=postgres
-DB_USER=pandora
-DB_PASSWORD=Pandora337303$
-FLASK_DEBUG=True
-PORT=5001
-```
+Crie arquivos `.env` a partir dos modelos de exemplo e preencha com suas credenciais:
 
-### `frontend/.env`
-```env
-REACT_APP_API_URL=http://localhost:5001/api
-REACT_APP_WS_URL=http://localhost:5001
-GEMINI_API_KEY=
-REACT_APP_ENV=development
+### Backend
+```bash
+cp backend/.env.example backend/.env
 ```
+Edite `backend/.env` com as configurações do banco, chave da API do Google Gemini e demais valores necessários.
+
+### Frontend
+```bash
+cp frontend/.env.example frontend/.env
+```
+Atualize `frontend/.env` com as URLs da API e a chave do Gemini antes de iniciar o projeto.
 
 ## Executar Testes
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,10 @@
+# Backend environment variables example
+DB_HOST=
+DB_PORT=5432
+DB_NAME=
+DB_USER=
+DB_PASSWORD=
+SECRET_KEY=
+FLASK_DEBUG=True
+PORT=5001
+GOOGLE_API_KEY=

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,4 @@
+# Frontend environment variables example
+VITE_BACKEND_URL=http://localhost:5001/api
+VITE_API_URL=http://localhost:5001
+GEMINI_API_KEY=


### PR DESCRIPTION
## Summary
- add backend/.env.example with required env keys
- add frontend/.env.example with required env keys
- update README with instructions to copy .env.example files and fill credentials

## Testing
- `npm test`
- `pytest` *(fails: Uma ou mais variáveis de ambiente do banco de dados não foram definidas)*

------
https://chatgpt.com/codex/tasks/task_e_68963af43bfc8327b9a0b5f247d7825b