### PR TITLE
feat: require MT5 credentials via env

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,17 @@ Backend:
 pytest -q
 ```
 
+### Testes com MetaTrader5
+
+Alguns testes dependem de credenciais do MetaTrader5. Defina as variáveis de ambiente antes de executá-los:
+
+```bash
+export MT5_LOGIN=seu_login
+export MT5_PASSWORD=sua_senha
+export MT5_SERVER=seu_servidor
+pytest -q test_cotacoes_mt5.py
+```
+
 Frontend:
 ```bash
 npm test

--- a/test_cotacoes_mt5.py
+++ b/test_cotacoes_mt5.py
@@ -2,6 +2,8 @@
 """
 Script para testar cotações MetaTrader5 - VERSÃO CORRIGIDA
 Não depende de seleção de símbolos
+
+Requer as variáveis de ambiente ``MT5_LOGIN``, ``MT5_PASSWORD`` e ``MT5_SERVER`` definidas.
 """
 
 import os
@@ -25,10 +27,16 @@ def test_mt5_quotes_fixed():
         return
     
     # Configurações
-    MT5_LOGIN = int(os.getenv("MT5_LOGIN", "5223688"))
-    MT5_PASSWORD = os.getenv("MT5_PASSWORD", "Pandora337303$")
-    MT5_SERVER = os.getenv("MT5_SERVER", "BancoBTGPactual-PRD")
-    
+    try:
+        MT5_LOGIN = int(os.environ["MT5_LOGIN"])
+        MT5_PASSWORD = os.environ["MT5_PASSWORD"]
+        MT5_SERVER = os.environ["MT5_SERVER"]
+    except KeyError as e:
+        raise EnvironmentError(
+            f"Variável de ambiente {e.args[0]} não definida. "
+            "Configure MT5_LOGIN, MT5_PASSWORD e MT5_SERVER antes de rodar o teste."
+        ) from e
+
     print(f"🔐 Login: {MT5_LOGIN}")
     print(f"🌐 Servidor: {MT5_SERVER}")
     


### PR DESCRIPTION
## Summary
- require MT5 credential variables in the MetaTrader5 test
- document MetaTrader5 credentials needed for tests

## Testing
- `export MT5_LOGIN=1`
- `export MT5_PASSWORD=pass`
- `export MT5_SERVER=server`
- `pytest -q` *(fails: Uma ou mais variáveis de ambiente do banco de dados não foram definidas)*

------
https://chatgpt.com/codex/tasks/task_e_689643431bc883279098ef8e15ba28df