### PR TITLE
Add CI workflow for backend and frontend tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,64 @@
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    env:
+      DB_USER: test
+      DB_PASSWORD: test
+      DB_HOST: localhost
+      DB_NAME: test
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt flake8
+      - name: Lint
+        run: |
+          flake8 . | tee flake8.log
+      - name: Run Pytest
+        run: |
+          pytest --junitxml=pytest-results.xml
+      - name: Upload backend results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-results
+          path: |
+            flake8.log
+            pytest-results.xml
+
+  frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Run frontend tests
+        run: |
+          cd frontend
+          npx vitest run --reporter=junit --outputFile=vitest-results.xml
+      - name: Upload frontend results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-results
+          path: frontend/vitest-results.xml


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run Python and frontend tests with linting
- publish test and lint artifacts for easier PR reviews

## Testing
- `pytest` *(fails: fixture 'method' not found)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68964815ac3c832783bf1fb59d728e50