### PR TITLE
Remove redundant db init in run_backend

### DIFF
--- a/run_backend.py
+++ b/run_backend.py
@@ -62,9 +62,6 @@ def main():
         
         # Inicializar database
         with app.app_context():
-            db.init_app(app)
-            logger.info("✅ SQLAlchemy inicializado")
-
             # Testar conexão PostgreSQL
             try:
                 db.session.execute(text('SELECT 1'))


### PR DESCRIPTION
## Summary
- use existing app initialization from backend package
- keep database connection check only in `run_backend`

## Testing
- `pytest -q` *(fails: ValueError: Uma ou mais variáveis de ambiente do banco de dados não foram definidas)*

------
https://chatgpt.com/codex/tasks/task_e_6896522e270883279428a5bc53f12382