### PR TITLE
feat: show spinner while loading stock guide

### DIFF
--- a/frontend/components/SellSideData.tsx
+++ b/frontend/components/SellSideData.tsx
@@ -253,7 +253,10 @@ const SellSideData: React.FC = () => {
                     {error ? (
                         <div className="text-red-500">{error}</div>
                     ) : loading ? (
-
+                        <div className="flex justify-center py-10" role="status">
+                            <div className="w-8 h-8 border-4 border-sky-400 border-t-transparent rounded-full animate-spin" />
+                            <span className="sr-only">Carregando...</span>
+                        </div>
                     ) : (
                         <StockGuideTable data={filteredData} />
                     )}


### PR DESCRIPTION
## Summary
- show spinner while SellSideData is loading

## Testing
- `npm run dev --workspace frontend`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896564527f483278cfd895def8fc207