### PR TITLE
Refactor MetaTrader5 worker startup

### DIFF
--- a/backend/services/metatrader5_rtd_worker.py
+++ b/backend/services/metatrader5_rtd_worker.py
@@ -172,6 +172,15 @@ class MetaTrader5RTDWorker:
             self.failed_symbols.add(symbol)
             return False
 
+    # --- Legacy compatibility methods ---
+    def initialize(self):
+        """Alias para initialize_mt5 para compatibilidade retroativa."""
+        return self.initialize_mt5()
+
+    def activate_realtime_for_symbol(self, symbol: str):
+        """Alias para _activate_realtime_for_symbol para compatibilidade retroativa."""
+        return self._activate_realtime_for_symbol(symbol)
+
     def get_mt5_quote(self, ticker: str) -> Optional[Dict]:
         """
         Obtém cotação EM TEMPO REAL do MetaTrader5.

--- a/run_backend.py
+++ b/run_backend.py
@@ -82,29 +82,15 @@ def main():
             
             logger.info("🔄 Inicializando MetaTrader5 Worker...")
             mt5_worker = MetaTrader5RTDWorker()
-            
-            if mt5_worker.initialize():
-                logger.info("✅ MetaTrader5 Worker inicializado")
-                
-                # Ativar tempo real para símbolos principais
-                principais = ['VALE3', 'PETR4', 'ITUB4', 'BBDC4', 'ABEV3']
-                logger.info("🚀 ATIVANDO TEMPO REAL PARA SÍMBOLOS PRINCIPAIS...")
-                
-                for symbol in principais:
-                    if mt5_worker.activate_realtime_for_symbol(symbol):
-                        logger.info(f"✅ {symbol}: Tempo real ATIVO")
-                    else:
-                        logger.warning(f"⚠️ {symbol}: Tempo real não disponível")
-                
-                # Iniciar worker
-                mt5_worker.start()
-                logger.info("🔄 MetaTrader5 Worker iniciado")
-                
-                # Armazenar worker no app
-                app.mt5_worker = mt5_worker
-                
-            else:
-                logger.warning("⚠️ MetaTrader5 não disponível")
+
+            mt5_worker.start()  # já inicializa MT5 internamente
+
+            principais = ["VALE3", "PETR4", "ITUB4", "BBDC4", "ABEV3"]
+            for symbol in principais:
+                mt5_worker.subscribe_ticker("startup", symbol)  # ativa tempo real
+
+            app.mt5_worker = mt5_worker
+            logger.info("✅ MetaTrader5 Worker em execução")
                 
         except Exception as e:
             logger.warning(f"⚠️ Erro ao inicializar MetaTrader5: {e}")


### PR DESCRIPTION
## Summary
- Simplify MetaTrader5 worker initialization and startup
- Add legacy compatibility aliases for outdated worker methods

## Testing
- `pytest -q` *(fails: Uma ou mais variáveis de ambiente do banco de dados não foram definidas)*

------
https://chatgpt.com/codex/tasks/task_e_6896580520308327a2edc988721621f2