### PR TITLE
feat: default tickers for realtime quotes

### DIFF
--- a/backend/routes/realtime_routes.py
+++ b/backend/routes/realtime_routes.py
@@ -23,9 +23,7 @@ def get_realtime_quotes_http():
     if not worker or not worker.mt5_connected:
         return jsonify({'status': 'error', 'message': 'Worker não inicializado'}), 503
 
-    tickers = request.args.getlist('tickers')
-    if not tickers:
-        return jsonify({'status': 'error', 'message': 'Nenhum ticker informado'}), 400
+    tickers = request.args.getlist("tickers") or ["VALE3", "PETR4", "ITUB4"]
 
     quotes = {}
     for t in tickers:
@@ -75,3 +73,4 @@ def register_socketio_events(socketio):
                 worker.unsubscribe_ticker(sid, ticker.upper())
         logger.info(f"Sessão {sid} cancelou subscrição de: {tickers}")
         emit('unsubscription_confirmed', {'tickers': tickers})
+


### PR DESCRIPTION
## Summary
- allow realtime quotes endpoint to use default tickers when none provided

## Testing
- `pytest` *(fails: Servidor não está respondendo, MetaTrader5 endpoints 0.0% functioning, Erro ao testar banco)*


------
https://chatgpt.com/codex/tasks/task_e_68965b40e1a08327a2dd616b07e2c1d3