### PR TITLE
feat: add health check endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,15 @@ npm run dev
 
 O dashboard estará disponível em `http://localhost:3000` e as APIs em `http://localhost:5001/api`.
 
+### Health checks
+
+Verifique rapidamente se o backend está no ar:
+
+```bash
+curl http://localhost:5001/health
+curl http://localhost:5001/api/health
+```
+
 ## Documentação Avançada
 
 Detalhes sobre a integração MetaTrader5 estão em [INTEGRACAO_METATRADER5.md](INTEGRACAO_METATRADER5.md).

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,7 +1,8 @@
-from flask import Flask
+from flask import Flask, jsonify
 from flask_cors import CORS
 from flask_sqlalchemy import SQLAlchemy
 from flask_socketio import SocketIO
+from sqlalchemy import text
 from .config import Config
 
 db = SQLAlchemy()
@@ -14,6 +15,19 @@ def create_app():
     
     db.init_app(app)
     socketio.init_app(app, cors_allowed_origins="*")
+
+    @app.route("/health")
+    def health_check():
+        return jsonify({"status": "ok"}), 200
+
+    @app.route("/api/health")
+    def api_health_check():
+        try:
+            db.session.execute(text("SELECT 1"))
+            db_status = "connected"
+        except Exception:
+            db_status = "disconnected"
+        return jsonify({"status": "ok", "database": db_status}), 200
 
     with app.app_context():
         # --- REGISTRO DE TODOS OS BLUEPRINTS ---

--- a/test_health_endpoints.py
+++ b/test_health_endpoints.py
@@ -1,0 +1,26 @@
+from backend import create_app
+from backend.config import Config
+import pytest
+
+
+@pytest.fixture
+def client():
+    Config.SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
+    app = create_app()
+    app.config['TESTING'] = True
+    with app.test_client() as client:
+        yield client
+
+
+def test_health(client):
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    assert resp.get_json() == {"status": "ok"}
+
+
+def test_api_health(client):
+    resp = client.get("/api/health")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["status"] == "ok"
+    assert data["database"] in ["connected", "disconnected"]


### PR DESCRIPTION
## Summary
- add basic `/health` route
- expose `/api/health` endpoint with database check
- document health endpoints and add tests

## Testing
- `PYTHONDONTWRITEBYTECODE=1 pytest test_health_endpoints.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68965b2a67808327b3ddae5dc0ac75ab