### PR TITLE
Log MetaTrader5 initialization failure details

### DIFF
--- a/backend/services/metatrader5_rtd_worker.py
+++ b/backend/services/metatrader5_rtd_worker.py
@@ -102,7 +102,7 @@ class MetaTrader5RTDWorker:
         try:
             # Inicializar MT5
             if not mt5.initialize():
-                logger.error("❌ Falha ao inicializar MetaTrader5")
+                logger.error(f"❌ Falha ao inicializar MetaTrader5: {mt5.last_error()}")
                 return False
             
             # Fazer login


### PR DESCRIPTION
## Summary
- log `mt5.last_error()` when MetaTrader5 fails to initialize to surface detailed error information

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896cbdfcc408327a6401a970fbea713