### PR TITLE
Handle MT5 worker startup failures

### DIFF
--- a/backend/services/metatrader5_rtd_worker.py
+++ b/backend/services/metatrader5_rtd_worker.py
@@ -388,17 +388,18 @@ class MetaTrader5RTDWorker:
         """Inicia o worker RTD em uma thread separada."""
         if self.running:
             logger.warning("⚠️ Worker já está rodando.")
-            return
-            
+            return True
+
         logger.info("🚀 Iniciando MetaTrader5 RTD Worker TEMPO REAL...")
-        if not self.initialize_mt5():
+        if not self.mt5_connected and not self.initialize_mt5():
             logger.critical("❌ Falha na inicialização do MT5. O worker não será iniciado.")
-            return
-            
+            return False
+
         self.running = True
         self.worker_thread = threading.Thread(target=self._price_update_loop, daemon=True)
         self.worker_thread.start()
         logger.info("✅ MetaTrader5 RTD Worker TEMPO REAL iniciado com sucesso.")
+        return True
     
     def stop(self):
         """Para o worker RTD e desliga a conexão com o MT5."""

--- a/run_backend.py
+++ b/run_backend.py
@@ -77,21 +77,25 @@ def main():
                 logger.info("🔄 Sistema funcionará com fallbacks")
         
         # Inicializar MetaTrader5 Worker
-        try:
-            from backend.services.metatrader5_rtd_worker import initialize_rtd_worker
+        from backend.services.metatrader5_rtd_worker import MetaTrader5RTDWorker
 
-            logger.info("🔄 Inicializando MetaTrader5 Worker...")
-            mt5_worker = initialize_rtd_worker(None)
+        logger.info("🔄 Inicializando MetaTrader5 Worker...")
+        mt5_worker = MetaTrader5RTDWorker(None)
 
-            principais = ["VALE3", "PETR4", "ITUB4", "BBDC4", "ABEV3"]
-            for symbol in principais:
-                mt5_worker.subscribe_ticker("startup", symbol)  # ativa tempo real
+        if not mt5_worker.initialize_mt5():
+            logger.critical("❌ MetaTrader5 não disponível. O backend será finalizado.")
+            raise RuntimeError("MetaTrader5 não disponível")
 
-            app.mt5_worker = mt5_worker
-            logger.info("✅ MetaTrader5 Worker em execução")
+        if mt5_worker.start() is False:
+            logger.critical("❌ Falha ao iniciar MetaTrader5 Worker. O backend será finalizado.")
+            raise RuntimeError("Falha ao iniciar MetaTrader5 Worker")
 
-        except Exception as e:
-            logger.warning(f"⚠️ Erro ao inicializar MetaTrader5: {e}")
+        principais = ["VALE3", "PETR4", "ITUB4", "BBDC4", "ABEV3"]
+        for symbol in principais:
+            mt5_worker.subscribe_ticker("startup", symbol)  # ativa tempo real
+
+        app.mt5_worker = mt5_worker
+        logger.info("✅ MetaTrader5 Worker em execução")
         
         # Adicionar headers CORS em todas as respostas
         @app.after_request


### PR DESCRIPTION
## Summary
- Replace try/except around MetaTrader5 worker setup with direct initialization
- Stop backend when MetaTrader5 is unavailable or fails to start
- Return boolean from MT5 worker start method for explicit failure checks

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896cd0b824c83278e97dbb9f3d0b577