### PR TITLE
Wrap MetaTrader5 worker init in try block

### DIFF
--- a/run_backend.py
+++ b/run_backend.py
@@ -77,23 +77,20 @@ def main():
                 logger.info("🔄 Sistema funcionará com fallbacks")
         
         # Inicializar MetaTrader5 Worker
-        from backend.services.metatrader5_rtd_worker import MetaTrader5RTDWorker
+        try:
+            from backend.services.metatrader5_rtd_worker import MetaTrader5RTDWorker
 
-        logger.info("🔄 Inicializando MetaTrader5 Worker...")
-        mt5_worker = MetaTrader5RTDWorker(None)
-
-        from backend.services.metatrader5_rtd_worker import MetaTrader5RTDWorker           
-        logger.info("🔄 Inicializando MetaTrader5 Worker...")
-        mt5_worker = MetaTrader5RTDWorker(None)         
-        if not mt5_worker.initialize_mt5():
-            logger.critical("❌ MetaTrader5 não disponível. O backend será finalizado.")
-            raise RuntimeError("MetaTrader5 não disponível")           
-        if mt5_worker.start() is False:
-            logger.critical("❌ Falha ao iniciar MetaTrader5 Worker. O backend será finalizado.")
-            raise RuntimeError("Falha ao iniciar MetaTrader5 Worker")
-        principais = ["VALE3", "PETR4", "ITUB4", "BBDC4", "ABEV3"]
-        for symbol in principais:
-            mt5_worker.subscribe_ticker("startup", symbol)  # ativa tempo real
+            logger.info("🔄 Inicializando MetaTrader5 Worker...")
+            mt5_worker = MetaTrader5RTDWorker(None)
+            if not mt5_worker.initialize_mt5():
+                logger.critical("❌ MetaTrader5 não disponível. O backend será finalizado.")
+                raise RuntimeError("MetaTrader5 não disponível")
+            if mt5_worker.start() is False:
+                logger.critical("❌ Falha ao iniciar MetaTrader5 Worker. O backend será finalizado.")
+                raise RuntimeError("Falha ao iniciar MetaTrader5 Worker")
+            principais = ["VALE3", "PETR4", "ITUB4", "BBDC4", "ABEV3"]
+            for symbol in principais:
+                mt5_worker.subscribe_ticker("startup", symbol)  # ativa tempo real
 
             app.mt5_worker = mt5_worker
             logger.info("✅ MetaTrader5 Worker em execução")


### PR DESCRIPTION
## Summary
- guard MetaTrader5 worker setup with try/except and drop duplicate import
- assign initialized worker to app after symbol subscriptions and log success

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896d87debc083279917bd3cb077ec5b