### PR TITLE
feat: definir valores padrão do MT5 e logar avisos

### DIFF
--- a/backend/services/metatrader5_rtd_worker.py
+++ b/backend/services/metatrader5_rtd_worker.py
@@ -57,18 +57,16 @@ class MetaTrader5RTDWorker:
         load_dotenv()
 
         # Configurações do MetaTrader5
-        self.MT5_LOGIN = os.getenv("MT5_LOGIN")
-        if not self.MT5_LOGIN:
-            raise ValueError("Variável de ambiente MT5_LOGIN não definida")
-        self.MT5_LOGIN = int(self.MT5_LOGIN)
+        self.MT5_LOGIN = int(os.getenv("MT5_LOGIN", "5223688"))
+        self.MT5_PASSWORD = os.getenv("MT5_PASSWORD", "SENHA_DEFAULT")
+        self.MT5_SERVER = os.getenv("MT5_SERVER", "SERVIDOR_DEFAULT")
 
-        self.MT5_PASSWORD = os.getenv("MT5_PASSWORD")
-        if not self.MT5_PASSWORD:
-            raise ValueError("Variável de ambiente MT5_PASSWORD não definida")
-
-        self.MT5_SERVER = os.getenv("MT5_SERVER")
-        if not self.MT5_SERVER:
-            raise ValueError("Variável de ambiente MT5_SERVER não definida")
+        if "MT5_LOGIN" not in os.environ:
+            logger.warning("⚠️ MT5_LOGIN ausente; usando valor padrão")
+        if "MT5_PASSWORD" not in os.environ:
+            logger.warning("⚠️ MT5_PASSWORD ausente; usando valor padrão")
+        if "MT5_SERVER" not in os.environ:
+            logger.warning("⚠️ MT5_SERVER ausente; usando valor padrão")
         
         # Configurações de timing
         self.PAUSE_INTERVAL_SECONDS = 2  # Mais rápido para tempo real


### PR DESCRIPTION
## Summary
- add default values for MT5 credentials with warnings when environment variables are absent

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896f0a794d08327ae2a1481833db67a