### PR TITLE
Abort server if MetaTrader5 worker fails to connect

### DIFF
--- a/run_backend.py
+++ b/run_backend.py
@@ -89,6 +89,9 @@ def main():
             if mt5_worker.start() is False:
                 logger.critical("❌ Falha ao iniciar MetaTrader5 Worker. O backend será finalizado.")
                 raise RuntimeError("Falha ao iniciar MetaTrader5 Worker")
+            if not mt5_worker.mt5_connected:
+                logger.critical("❌ MT5 não conectou; abortando servidor.")
+                raise SystemExit(1)
             principais = ["VALE3", "PETR4", "ITUB4", "BBDC4", "ABEV3"]
             for symbol in principais:
                 mt5_worker.subscribe_ticker("startup", symbol)  # ativa tempo real


### PR DESCRIPTION
## Summary
- Check `mt5_connected` after worker start and abort if MetaTrader5 fails to connect

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6899369b518c8327b4bbc09acc7f6727