### PR TITLE
Expose company info in document lookup

### DIFF
--- a/backend/routes/documents_routes.py
+++ b/backend/routes/documents_routes.py
@@ -24,14 +24,21 @@ def get_documents_by_company_id(company_id):
 
         doc_list = [{
             "id": doc.id,
+            "company_name": company.company_name,
+            "ticker": company.ticker,
             "document_type": doc.document_type,
             "category": doc.category,
             "title": doc.title,
             "delivery_date": doc.delivery_date.isoformat() if doc.delivery_date else None,
             "download_url": doc.download_url
         } for doc in docs]
-        
-        return jsonify({"success": True, "company_name": company.company_name, "documents": doc_list})
+
+        return jsonify({
+            "success": True,
+            "company_name": company.company_name,
+            "ticker": company.ticker,
+            "documents": doc_list,
+        })
     except Exception as e:
         logger.error(f"Erro em get_documents_by_company_id: {e}")
         return jsonify({"success": False, "error": "Erro interno ao buscar documentos"}), 500


### PR DESCRIPTION
## Summary
- add company_name and ticker details to each item in `/by_company/<company_id>` document list
- return top-level ticker alongside company name

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68995e6e676883278428d78564dc1afe