### PR TITLE
fix: return document_types key from CVM endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,23 @@ curl http://localhost:5001/health
 curl http://localhost:5001/api/health
 ```
 
+### Exemplo de rota CVM
+
+Para listar os tipos de documentos disponíveis:
+
+```bash
+curl http://localhost:5001/api/cvm/document-types
+```
+
+Resposta:
+
+```json
+{
+  "success": true,
+  "document_types": ["DFP", "ITR", "..."]
+}
+```
+
 ## Documentação Avançada
 
 Detalhes sobre a integração MetaTrader5 estão em [INTEGRACAO_METATRADER5.md](INTEGRACAO_METATRADER5.md).

--- a/backend/routes/documents_routes.py
+++ b/backend/routes/documents_routes.py
@@ -69,8 +69,8 @@ def list_cvm_documents():
 def list_document_types():
     """Retorna tipos de documentos disponíveis."""
     try:
-        types = [r[0] for r in db.session.query(CvmDocument.document_type).distinct().order_by(CvmDocument.document_type)]
-        return jsonify({"success": True, "types": types})
+        document_types = [r[0] for r in db.session.query(CvmDocument.document_type).distinct().order_by(CvmDocument.document_type)]
+        return jsonify({"success": True, "document_types": document_types})
     except Exception as e:
         logger.error(f"Erro em list_document_types: {e}")
         return jsonify({"success": False, "error": "Erro ao listar tipos"}), 500

--- a/test_404.py
+++ b/test_404.py
@@ -17,3 +17,6 @@ def test_fixed_endpoints(client, method, endpoint, payload):
     response = client.open(endpoint, method=method, json=payload)
     assert response.status_code == 200
     assert response.is_json
+    data = response.get_json()
+    if endpoint == "/api/cvm/document-types":
+        assert "document_types" in data


### PR DESCRIPTION
## Summary
- return `document_types` instead of `types` in document types endpoint
- document the new key and verify it via tests

## Testing
- `pytest -q`
- `npm test >/tmp/npm_test.log && tail -n 20 /tmp/npm_test.log`


------
https://chatgpt.com/codex/tasks/task_e_68995e6573e8832799bf9735bc32b863