### PR TITLE
Map CVM document types to structured objects

### DIFF
--- a/backend/routes/documents_routes.py
+++ b/backend/routes/documents_routes.py
@@ -76,7 +76,16 @@ def list_cvm_documents():
 def list_document_types():
     """Retorna tipos de documentos disponíveis."""
     try:
-        document_types = [r[0] for r in db.session.query(CvmDocument.document_type).distinct().order_by(CvmDocument.document_type)]
+        document_types_raw = [
+            r[0]
+            for r in db.session.query(CvmDocument.document_type)
+            .distinct()
+            .order_by(CvmDocument.document_type)
+        ]
+        document_types = [
+            {"code": dt, "name": dt, "description": dt}
+            for dt in document_types_raw
+        ]
         return jsonify({"success": True, "document_types": document_types})
     except Exception as e:
         logger.error(f"Erro em list_document_types: {e}")

--- a/frontend/services/cvmService.test.ts
+++ b/frontend/services/cvmService.test.ts
@@ -23,7 +23,21 @@ describe('cvmService', () => {
   });
 
   it('getDocumentTypes retorna lista de categorias', async () => {
-    const mockTypes = [{ code: 'CAT', description: 'Categoria' }];
+    const mockTypes = ['CAT'];
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ document_types: mockTypes })
+    }));
+    const types = await cvmService.getDocumentTypes();
+    expect(types).toEqual([
+      { code: 'CAT', name: 'CAT', description: 'CAT' }
+    ]);
+  });
+
+  it('getDocumentTypes lida com objetos preformatados', async () => {
+    const mockTypes = [
+      { code: 'CAT', name: 'Categoria', description: 'Categoria' }
+    ];
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
       ok: true,
       json: async () => ({ document_types: mockTypes })

--- a/frontend/services/cvmService.ts
+++ b/frontend/services/cvmService.ts
@@ -13,7 +13,11 @@ const getDocumentTypes = async (): Promise<CvmDocumentType[]> => {
     const response = await fetch(`${API_BASE_URL}/cvm/document-types`);
     if (!response.ok) throw new Error('Erro ao buscar tipos de documento');
     const data = await response.json();
-    return data.document_types || [];
+    return (data.document_types || []).map((d: any) =>
+        typeof d === 'string'
+            ? { code: d, name: d, description: d }
+            : d
+    );
 };
 
 interface DocumentFilter {


### PR DESCRIPTION
## Summary
- Convert CVM document types from strings to structured objects on the frontend
- Handle preformatted document type objects in service tests
- Expose document types as structured objects in backend route

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68998076b190832784dd54c2816bc25b