### PR TITLE
Inclui /api na URL base do serviço CVM

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,4 +1,4 @@
 # Frontend environment variables example
 VITE_BACKEND_URL=http://localhost:5001/api
-VITE_API_URL=http://localhost:5001
+VITE_API_URL=http://localhost:5001/api
 GEMINI_API_KEY=

--- a/frontend/services/cvmService.ts
+++ b/frontend/services/cvmService.ts
@@ -1,6 +1,6 @@
 import { CvmDocument, CvmCompany, CvmDocumentType } from '../types';
 
-const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:5001';
+const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:5001/api';
 
 const getCompanies = async (): Promise<CvmCompany[]> => {
     const response = await fetch(`${API_BASE_URL}/cvm/companies`);


### PR DESCRIPTION
## Summary
- garante que a constante API_BASE_URL inclua `/api`
- ajusta `.env.example` para refletir a URL com `/api`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68998073b14c8327bc8caa43c89b9cab