### PR TITLE
feat: integrate research notes with API

### DIFF
--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -485,10 +485,10 @@ export interface StockGuideData {
 
 // Research Page Types
 export interface ResearchNote {
-    id: string;
+    id: number;
     title: string;
     content: string;
-    lastUpdated: string;
+    last_updated: string;
 }
 
 // Company News Page Types


### PR DESCRIPTION
## Summary
- load research notes from API on mount and track active note
- support creating, updating, and deleting notes via REST endpoints
- switch ResearchNote type to numeric id and snake_case timestamps

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689983895ad08327982b6a09a462b932