### PR TITLE
Add research notes model and CRUD endpoints

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -43,6 +43,7 @@ def create_app():
         from .routes.screening_routes import screening_bp
         from .routes.search_routes import search_bp
         from .routes.macro_routes import macro_bp
+        from .routes.research_routes import research_bp
 
         app.register_blueprint(companies_bp, url_prefix='/api/companies')
         app.register_blueprint(tickers_bp, url_prefix='/api/tickers')
@@ -57,6 +58,7 @@ def create_app():
         app.register_blueprint(screening_bp, url_prefix='/api/screening')
         app.register_blueprint(search_bp, url_prefix='/api/search')
         app.register_blueprint(macro_bp, url_prefix='/api/macro')
+        app.register_blueprint(research_bp, url_prefix='/api/research')
 
         db.create_all()
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -198,3 +198,14 @@ class PortfolioDailyValue(db.Model):
     __table_args__ = (
         db.UniqueConstraint('portfolio_id', 'date', name='uix_portfolio_date'),
     )
+
+
+class ResearchNote(db.Model):
+    __tablename__ = 'research_notes'
+
+    id = db.Column(Integer, primary_key=True)
+    title = db.Column(String(255), nullable=False)
+    content = db.Column(Text, nullable=False)
+    last_updated = db.Column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )

--- a/backend/routes/research_routes.py
+++ b/backend/routes/research_routes.py
@@ -1,0 +1,101 @@
+import logging
+from flask import Blueprint, jsonify, request
+
+from backend.models import db, ResearchNote
+
+logger = logging.getLogger(__name__)
+research_bp = Blueprint('research_bp', __name__)
+
+
+@research_bp.route('/notes', methods=['GET'])
+def list_notes():
+    try:
+        notes = ResearchNote.query.order_by(ResearchNote.last_updated.desc()).all()
+        data = [
+            {
+                'id': n.id,
+                'title': n.title,
+                'content': n.content,
+                'last_updated': n.last_updated.isoformat() if n.last_updated else None,
+            }
+            for n in notes
+        ]
+        return jsonify({'success': True, 'notes': data})
+    except Exception as e:
+        logger.error(f'Erro ao listar notas: {e}')
+        return jsonify({'success': False, 'error': 'Erro ao listar notas'}), 500
+
+
+@research_bp.route('/notes', methods=['POST'])
+def create_note():
+    data = request.get_json(silent=True) or {}
+    title = data.get('title')
+    content = data.get('content')
+    if not title or not content:
+        return jsonify({'success': False, 'error': 'Campos obrigatórios não fornecidos'}), 400
+    try:
+        note = ResearchNote(title=title, content=content)
+        db.session.add(note)
+        db.session.commit()
+        return (
+            jsonify(
+                {
+                    'success': True,
+                    'note': {
+                        'id': note.id,
+                        'title': note.title,
+                        'content': note.content,
+                        'last_updated': note.last_updated.isoformat() if note.last_updated else None,
+                    },
+                }
+            ),
+            201,
+        )
+    except Exception as e:
+        db.session.rollback()
+        logger.error(f'Erro ao criar nota: {e}')
+        return jsonify({'success': False, 'error': 'Erro ao criar nota'}), 500
+
+
+@research_bp.route('/notes/<int:note_id>', methods=['PUT'])
+def update_note(note_id: int):
+    data = request.get_json(silent=True) or {}
+    try:
+        note = ResearchNote.query.get(note_id)
+        if not note:
+            return jsonify({'success': False, 'error': 'Nota não encontrada'}), 404
+        if 'title' in data:
+            note.title = data['title']
+        if 'content' in data:
+            note.content = data['content']
+        db.session.commit()
+        return jsonify(
+            {
+                'success': True,
+                'note': {
+                    'id': note.id,
+                    'title': note.title,
+                    'content': note.content,
+                    'last_updated': note.last_updated.isoformat() if note.last_updated else None,
+                },
+            }
+        )
+    except Exception as e:
+        db.session.rollback()
+        logger.error(f'Erro ao atualizar nota {note_id}: {e}')
+        return jsonify({'success': False, 'error': 'Erro ao atualizar nota'}), 500
+
+
+@research_bp.route('/notes/<int:note_id>', methods=['DELETE'])
+def delete_note(note_id: int):
+    try:
+        note = ResearchNote.query.get(note_id)
+        if not note:
+            return jsonify({'success': False, 'error': 'Nota não encontrada'}), 404
+        db.session.delete(note)
+        db.session.commit()
+        return jsonify({'success': True})
+    except Exception as e:
+        db.session.rollback()
+        logger.error(f'Erro ao deletar nota {note_id}: {e}')
+        return jsonify({'success': False, 'error': 'Erro ao deletar nota'}), 500

--- a/test_research_routes.py
+++ b/test_research_routes.py
@@ -1,0 +1,29 @@
+import pytest
+
+
+def test_research_notes_crud(client):
+    # initially empty
+    resp = client.get('/api/research/notes')
+    assert resp.status_code == 200
+    assert resp.get_json()['notes'] == []
+
+    # create
+    resp = client.post('/api/research/notes', json={'title': 'Note1', 'content': 'Content1'})
+    assert resp.status_code == 201
+    note = resp.get_json()['note']
+    note_id = note['id']
+    assert note['title'] == 'Note1'
+
+    # update
+    resp = client.put(f'/api/research/notes/{note_id}', json={'title': 'Updated', 'content': 'Updated'})
+    assert resp.status_code == 200
+    assert resp.get_json()['note']['title'] == 'Updated'
+
+    # delete
+    resp = client.delete(f'/api/research/notes/{note_id}')
+    assert resp.status_code == 200
+
+    # ensure empty again
+    resp = client.get('/api/research/notes')
+    assert resp.status_code == 200
+    assert resp.get_json()['notes'] == []


### PR DESCRIPTION
## Summary
- add `ResearchNote` SQLAlchemy model for storing research notes
- create research notes CRUD API blueprint and register under `/api/research`
- add tests covering research note lifecycle

## Testing
- `pytest -q`
- `python - <<'PY'
from backend import create_app, db
from backend.config import Config
Config.SQLALCHEMY_DATABASE_URI = 'sqlite:///:memory:'
app = create_app()
with app.app_context():
    from sqlalchemy import inspect
    inspector = inspect(db.engine)
    print('research_notes' in inspector.get_table_names())
PY`


------
https://chatgpt.com/codex/tasks/task_e_689983843ccc832794bffc0ca8c10810