### PR TITLE
feat: fetch company news from backend

### DIFF
--- a/frontend/services/newsService.ts
+++ b/frontend/services/newsService.ts
@@ -1,0 +1,22 @@
+import { CompanyNewsItem } from '../types';
+
+const API_BASE = import.meta.env.VITE_BACKEND_URL || 'http://localhost:5001/api';
+
+const getCompanyNews = async (ticker: string): Promise<CompanyNewsItem[]> => {
+  const res = await fetch(`${API_BASE}/news/company/${ticker}`);
+  if (!res.ok) {
+    throw new Error('Falha ao buscar notícias da empresa');
+  }
+  const json = await res.json();
+  const items = (json.news || json.data || json) as any[];
+  return items.map((item: any) => ({
+    id: String(item.id ?? crypto.randomUUID()),
+    title: item.titulo,
+    summary: item.resumo,
+    source: item.portal,
+    publishedDate: item.data_publicacao,
+    url: item.link_url,
+  }));
+};
+
+export const newsService = { getCompanyNews };


### PR DESCRIPTION
## Summary
- add news service to retrieve company news from API
- integrate company news component with backend service and reload on ticker change

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899835e3bd88327a23815aa9915e25d