### PR TITLE
feat: add market articles news API

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -43,6 +43,7 @@ def create_app():
         from .routes.screening_routes import screening_bp
         from .routes.search_routes import search_bp
         from .routes.macro_routes import macro_bp
+        from .routes.news_routes import news_bp
 
         app.register_blueprint(companies_bp, url_prefix='/api/companies')
         app.register_blueprint(tickers_bp, url_prefix='/api/tickers')
@@ -57,6 +58,7 @@ def create_app():
         app.register_blueprint(screening_bp, url_prefix='/api/screening')
         app.register_blueprint(search_bp, url_prefix='/api/search')
         app.register_blueprint(macro_bp, url_prefix='/api/macro')
+        app.register_blueprint(news_bp, url_prefix='/api/news')
 
         db.create_all()
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -142,6 +142,25 @@ class AssetMetrics(db.Model):
     ticker_info = relationship("Ticker", back_populates="metrics")
 
 
+class MarketArticle(db.Model):
+    __tablename__ = 'artigos_mercado'
+
+    id = db.Column(Integer, primary_key=True)
+    titulo = db.Column(String(255), nullable=False)
+    link_url = db.Column(String(500))
+    portal = db.Column(String(255))
+    resumo = db.Column(Text)
+    conteudo_completo = db.Column(Text)
+    autor = db.Column(String(255))
+    data_publicacao = db.Column(DateTime)
+    categoria = db.Column(String(255))
+    tickers_relacionados = db.Column(Text)
+    score_impacto = db.Column(Numeric(10, 4))
+
+    def to_dict(self):
+        return {c.name: getattr(self, c.name) for c in self.__table__.columns}
+
+
 class Portfolio(db.Model):
     __tablename__ = 'portfolios'
 

--- a/backend/routes/news_routes.py
+++ b/backend/routes/news_routes.py
@@ -1,0 +1,28 @@
+from flask import Blueprint, jsonify, request
+from backend.models import MarketArticle
+
+news_bp = Blueprint('news_bp', __name__)
+
+
+@news_bp.route('/company/<string:ticker>', methods=['GET'])
+def get_news_by_ticker(ticker):
+    ticker_upper = ticker.upper()
+    articles = (
+        MarketArticle.query
+        .filter(MarketArticle.tickers_relacionados.ilike(f"%{ticker_upper}%"))
+        .order_by(MarketArticle.data_publicacao.desc())
+        .all()
+    )
+    return jsonify([a.to_dict() for a in articles])
+
+
+@news_bp.route('/latest', methods=['GET'])
+def get_latest_news():
+    limit = request.args.get('limit', 10, type=int)
+    articles = (
+        MarketArticle.query
+        .order_by(MarketArticle.data_publicacao.desc())
+        .limit(limit)
+        .all()
+    )
+    return jsonify([a.to_dict() for a in articles])


### PR DESCRIPTION
## Summary
- add `MarketArticle` model for `artigos_mercado`
- expose news endpoints to fetch articles by ticker or latest
- register news blueprint in application factory

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899835acb008327a36db648e5c693f7