### PR TITLE
fix: normalize API base URL

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:5001

--- a/frontend/services/cvmService.ts
+++ b/frontend/services/cvmService.ts
@@ -1,6 +1,7 @@
 import { CvmDocument, CvmCompany, CvmDocumentType } from '../types';
 
-const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:5001/api';
+const base = import.meta.env.VITE_API_URL || 'http://localhost:5001';
+const API_BASE_URL = base.endsWith('/api') ? base : `${base}/api`;
 
 const getCompanies = async (): Promise<CvmCompany[]> => {
     const response = await fetch(`${API_BASE_URL}/cvm/companies`);


### PR DESCRIPTION
## Summary
- ensure API base URL automatically appends /api when missing
- add frontend .env with VITE_API_URL without /api

## Testing
- `npm test`
- `npm run build --workspace frontend`


------
https://chatgpt.com/codex/tasks/task_e_68998850d6408327b777ed02b7750906