### PR TITLE
Allow creating empty research note content

### DIFF
--- a/backend/routes/research_routes.py
+++ b/backend/routes/research_routes.py
@@ -30,8 +30,8 @@ def list_notes():
 def create_note():
     data = request.get_json(silent=True) or {}
     title = data.get('title')
-    content = data.get('content')
-    if not title or not content:
+    content = data.get('content', '')
+    if not title:
         return jsonify({'success': False, 'error': 'Campos obrigatórios não fornecidos'}), 400
     try:
         note = ResearchNote(title=title, content=content)

--- a/test_research_routes.py
+++ b/test_research_routes.py
@@ -27,3 +27,10 @@ def test_research_notes_crud(client):
     resp = client.get('/api/research/notes')
     assert resp.status_code == 200
     assert resp.get_json()['notes'] == []
+
+def test_create_note_without_content(client):
+    resp = client.post('/api/research/notes', json={'title': 'Only title'})
+    assert resp.status_code == 201
+    note = resp.get_json()['note']
+    assert note['content'] == ''
+    client.delete(f"/api/research/notes/{note['id']}")


### PR DESCRIPTION
## Summary
- allow research notes to be created without content
- add test for creating note with missing content

## Testing
- `pytest test_research_routes.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6899e1475f3883278274bd918adfdf90