### PR TITLE
feat: support summary field in research notes

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -224,6 +224,7 @@ class ResearchNote(db.Model):
 
     id = db.Column(Integer, primary_key=True)
     title = db.Column(String(255), nullable=False)
+    summary = db.Column(Text, nullable=True)
     content = db.Column(Text, nullable=False)
     last_updated = db.Column(
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now()

--- a/backend/routes/research_routes.py
+++ b/backend/routes/research_routes.py
@@ -15,6 +15,7 @@ def list_notes():
             {
                 'id': n.id,
                 'title': n.title,
+                'summary': n.summary,
                 'content': n.content,
                 'last_updated': n.last_updated.isoformat() if n.last_updated else None,
             }
@@ -30,11 +31,12 @@ def list_notes():
 def create_note():
     data = request.get_json(silent=True) or {}
     title = data.get('title')
+    summary = data.get('summary', '')
     content = data.get('content')
-    if not title or not content:
+    if not title or content is None:
         return jsonify({'success': False, 'error': 'Campos obrigatórios não fornecidos'}), 400
     try:
-        note = ResearchNote(title=title, content=content)
+        note = ResearchNote(title=title, summary=summary, content=content)
         db.session.add(note)
         db.session.commit()
         return (
@@ -44,6 +46,7 @@ def create_note():
                     'note': {
                         'id': note.id,
                         'title': note.title,
+                        'summary': note.summary,
                         'content': note.content,
                         'last_updated': note.last_updated.isoformat() if note.last_updated else None,
                     },
@@ -66,6 +69,8 @@ def update_note(note_id: int):
             return jsonify({'success': False, 'error': 'Nota não encontrada'}), 404
         if 'title' in data:
             note.title = data['title']
+        if 'summary' in data:
+            note.summary = data['summary']
         if 'content' in data:
             note.content = data['content']
         db.session.commit()
@@ -75,6 +80,7 @@ def update_note(note_id: int):
                 'note': {
                     'id': note.id,
                     'title': note.title,
+                    'summary': note.summary,
                     'content': note.content,
                     'last_updated': note.last_updated.isoformat() if note.last_updated else None,
                 },

--- a/frontend/components/Research.tsx
+++ b/frontend/components/Research.tsx
@@ -14,7 +14,8 @@ const Research: React.FC = () => {
             try {
                 const res = await fetch('/api/research/notes');
                 if (res.ok) {
-                    const data: ResearchNote[] = await res.json();
+                    const json = await res.json();
+                    const data: ResearchNote[] = json.notes;
                     setNotes(data);
                     setActiveNoteId(data[0]?.id ?? null);
                 }
@@ -30,10 +31,11 @@ const Research: React.FC = () => {
             const res = await fetch('/api/research/notes', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ title: 'Nova Anotação', content: '' })
+                body: JSON.stringify({ title: 'Nova Anotação', summary: '', content: '' })
             });
             if (res.ok) {
-                const newNote: ResearchNote = await res.json();
+                const json = await res.json();
+                const newNote: ResearchNote = json.note;
                 setNotes(prev => [newNote, ...prev]);
                 setActiveNoteId(newNote.id);
             }
@@ -57,7 +59,7 @@ const Research: React.FC = () => {
         }
     };
 
-    const handleUpdateNote = (field: 'title' | 'content', value: string) => {
+    const handleUpdateNote = (field: 'title' | 'summary' | 'content', value: string) => {
         if (!activeNoteId) return;
         setNotes(prevNotes => {
             const updated = prevNotes.map(note =>
@@ -77,8 +79,9 @@ const Research: React.FC = () => {
         });
     };
 
-    const filteredNotes = notes.filter(note => 
-        note.title.toLowerCase().includes(searchTerm.toLowerCase()) || 
+    const filteredNotes = notes.filter(note =>
+        note.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
+        note.summary.toLowerCase().includes(searchTerm.toLowerCase()) ||
         note.content.toLowerCase().includes(searchTerm.toLowerCase())
     );
 
@@ -120,7 +123,7 @@ const Research: React.FC = () => {
                         >
                             <h3 className="font-semibold text-white truncate">{note.title}</h3>
                             <p className="text-sm text-slate-400 truncate mt-1">
-                                {note.content.split('\n')[0] || 'Nenhum conteúdo adicional'}
+                                {note.summary || note.content.split('\n')[0] || 'Nenhum conteúdo adicional'}
                             </p>
                             <p className="text-xs text-slate-500 mt-2">{formatDate(note.last_updated)}</p>
                         </div>
@@ -139,12 +142,19 @@ const Research: React.FC = () => {
                             </button>
                         </div>
                         <div className="flex-grow flex flex-col overflow-y-auto">
-                           <input 
+                           <input
                                 type="text"
                                 value={activeNote.title}
                                 onChange={(e) => handleUpdateNote('title', e.target.value)}
                                 className="w-full p-4 text-2xl font-bold bg-transparent text-white focus:outline-none placeholder-slate-500"
                                 placeholder="Título da nota"
+                           />
+                           <input
+                                type="text"
+                                value={activeNote.summary}
+                                onChange={(e) => handleUpdateNote('summary', e.target.value)}
+                                className="w-full p-4 bg-transparent text-slate-300 focus:outline-none placeholder-slate-500"
+                                placeholder="Resumo da nota"
                            />
                            <textarea
                                 value={activeNote.content}
@@ -152,9 +162,9 @@ const Research: React.FC = () => {
                                 className="w-full h-full flex-grow p-4 bg-transparent text-slate-300 focus:outline-none resize-none placeholder-slate-500"
                                 placeholder="Comece a escrever sua análise aqui..."
                            />
-                        </div>
-                    </>
-                ) : (
+                       </div>
+                   </>
+               ) : (
                     <div className="flex items-center justify-center h-full text-center text-slate-500">
                         <div>
                             <h2 className="text-xl font-semibold">Nenhuma nota selecionada</h2>

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -487,6 +487,7 @@ export interface StockGuideData {
 export interface ResearchNote {
     id: number;
     title: string;
+    summary: string;
     content: string;
     last_updated: string;
 }

--- a/test_research_routes.py
+++ b/test_research_routes.py
@@ -8,16 +8,22 @@ def test_research_notes_crud(client):
     assert resp.get_json()['notes'] == []
 
     # create
-    resp = client.post('/api/research/notes', json={'title': 'Note1', 'content': 'Content1'})
+    resp = client.post('/api/research/notes', json={'title': 'Note1', 'summary': 'Summary1', 'content': 'Content1'})
     assert resp.status_code == 201
     note = resp.get_json()['note']
     note_id = note['id']
     assert note['title'] == 'Note1'
+    assert note['summary'] == 'Summary1'
 
     # update
-    resp = client.put(f'/api/research/notes/{note_id}', json={'title': 'Updated', 'content': 'Updated'})
+    resp = client.put(
+        f'/api/research/notes/{note_id}',
+        json={'title': 'Updated', 'summary': 'Sum2', 'content': 'Updated'},
+    )
     assert resp.status_code == 200
-    assert resp.get_json()['note']['title'] == 'Updated'
+    updated = resp.get_json()['note']
+    assert updated['title'] == 'Updated'
+    assert updated['summary'] == 'Sum2'
 
     # delete
     resp = client.delete(f'/api/research/notes/{note_id}')


### PR DESCRIPTION
## Summary
- extend backend research notes to store a summary field
- support real-time editing of title, summary, and content on the Research page
- cover new summary field with tests

## Testing
- `pytest`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899e18b907c83279f84d8804a6107d7