### PR TITLE
Add CRUD for company news notes

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -45,6 +45,7 @@ def create_app():
         from .routes.macro_routes import macro_bp
         from .routes.news_routes import news_bp
         from .routes.research_routes import research_bp
+        from .routes.company_news_routes import company_news_bp
 
 
         app.register_blueprint(companies_bp, url_prefix='/api/companies')
@@ -62,6 +63,7 @@ def create_app():
         app.register_blueprint(macro_bp, url_prefix='/api/macro')
         app.register_blueprint(news_bp, url_prefix='/api/news')
         app.register_blueprint(research_bp, url_prefix='/api/research')
+        app.register_blueprint(company_news_bp, url_prefix='/api/company-news')
 
 
         db.create_all()

--- a/backend/models.py
+++ b/backend/models.py
@@ -228,3 +228,34 @@ class ResearchNote(db.Model):
     last_updated = db.Column(
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
     )
+
+
+class CompanyNewsNote(db.Model):
+    __tablename__ = 'company_news_notes'
+
+    id = db.Column(Integer, primary_key=True)
+    ticker = db.Column(String(20), nullable=False, index=True)
+    title = db.Column(String(255), nullable=False)
+    url = db.Column(String(500))
+    source = db.Column(String(255))
+    summary = db.Column(Text)
+    content = db.Column(Text)
+    author = db.Column(String(255))
+    published_at = db.Column(DateTime)
+    created_at = db.Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = db.Column(DateTime(timezone=True), onupdate=func.now())
+
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'ticker': self.ticker,
+            'title': self.title,
+            'url': self.url,
+            'source': self.source,
+            'summary': self.summary,
+            'content': self.content,
+            'author': self.author,
+            'published_at': self.published_at.isoformat() if self.published_at else None,
+            'created_at': self.created_at.isoformat() if self.created_at else None,
+            'updated_at': self.updated_at.isoformat() if self.updated_at else None,
+        }

--- a/backend/routes/company_news_routes.py
+++ b/backend/routes/company_news_routes.py
@@ -1,0 +1,97 @@
+import logging
+from datetime import datetime
+from flask import Blueprint, jsonify, request
+
+from backend.models import db, CompanyNewsNote
+
+logger = logging.getLogger(__name__)
+company_news_bp = Blueprint('company_news_bp', __name__)
+
+
+@company_news_bp.route('/<string:ticker>', methods=['GET'])
+def list_notes(ticker: str):
+    try:
+        notes = (
+            CompanyNewsNote.query
+            .filter_by(ticker=ticker.upper())
+            .order_by(CompanyNewsNote.published_at.desc())
+            .all()
+        )
+        return jsonify({'success': True, 'notes': [n.to_dict() for n in notes]})
+    except Exception as e:
+        logger.error(f'Erro ao listar notas para {ticker}: {e}')
+        return jsonify({'success': False, 'error': 'Erro ao listar notas'}), 500
+
+
+@company_news_bp.route('', methods=['POST'])
+def create_note():
+    data = request.get_json(silent=True) or {}
+    ticker = data.get('ticker')
+    title = data.get('title')
+    if not ticker or not title:
+        return jsonify({'success': False, 'error': 'Campos obrigatórios não fornecidos'}), 400
+    try:
+        published_at = datetime.fromisoformat(data['published_at']) if data.get('published_at') else None
+        note = CompanyNewsNote(
+            ticker=ticker.upper(),
+            title=title,
+            url=data.get('url'),
+            source=data.get('source'),
+            summary=data.get('summary'),
+            content=data.get('content'),
+            author=data.get('author'),
+            published_at=published_at,
+        )
+        db.session.add(note)
+        db.session.commit()
+        return jsonify({'success': True, 'note': note.to_dict()}), 201
+    except Exception as e:
+        db.session.rollback()
+        logger.error(f'Erro ao criar nota: {e}')
+        return jsonify({'success': False, 'error': 'Erro ao criar nota'}), 500
+
+
+@company_news_bp.route('/<int:note_id>', methods=['PUT'])
+def update_note(note_id: int):
+    data = request.get_json(silent=True) or {}
+    try:
+        note = CompanyNewsNote.query.get(note_id)
+        if not note:
+            return jsonify({'success': False, 'error': 'Nota não encontrada'}), 404
+        if 'ticker' in data:
+            note.ticker = data['ticker'].upper()
+        if 'title' in data:
+            note.title = data['title']
+        if 'url' in data:
+            note.url = data['url']
+        if 'source' in data:
+            note.source = data['source']
+        if 'summary' in data:
+            note.summary = data['summary']
+        if 'content' in data:
+            note.content = data['content']
+        if 'author' in data:
+            note.author = data['author']
+        if 'published_at' in data:
+            note.published_at = datetime.fromisoformat(data['published_at']) if data['published_at'] else None
+        db.session.commit()
+        return jsonify({'success': True, 'note': note.to_dict()})
+    except Exception as e:
+        db.session.rollback()
+        logger.error(f'Erro ao atualizar nota {note_id}: {e}')
+        return jsonify({'success': False, 'error': 'Erro ao atualizar nota'}), 500
+
+
+@company_news_bp.route('/<int:note_id>', methods=['DELETE'])
+def delete_note(note_id: int):
+    try:
+        note = CompanyNewsNote.query.get(note_id)
+        if not note:
+            return jsonify({'success': False, 'error': 'Nota não encontrada'}), 404
+        db.session.delete(note)
+        db.session.commit()
+        return jsonify({'success': True})
+    except Exception as e:
+        db.session.rollback()
+        logger.error(f'Erro ao deletar nota {note_id}: {e}')
+        return jsonify({'success': False, 'error': 'Erro ao deletar nota'}), 500

--- a/test_company_news_routes.py
+++ b/test_company_news_routes.py
@@ -1,0 +1,38 @@
+import pytest
+
+
+def test_company_news_crud(client):
+    # initially empty
+    resp = client.get('/api/company-news/ABCD')
+    assert resp.status_code == 200
+    assert resp.get_json()['notes'] == []
+
+    # create
+    resp = client.post('/api/company-news', json={
+        'ticker': 'ABCD',
+        'title': 'Note1',
+        'url': 'http://example.com',
+        'source': 'Source',
+        'summary': 'Summary',
+        'content': 'Content',
+        'author': 'Author',
+        'published_at': '2024-01-01T00:00:00'
+    })
+    assert resp.status_code == 201
+    note = resp.get_json()['note']
+    note_id = note['id']
+    assert note['ticker'] == 'ABCD'
+
+    # update
+    resp = client.put(f'/api/company-news/{note_id}', json={'title': 'Updated'})
+    assert resp.status_code == 200
+    assert resp.get_json()['note']['title'] == 'Updated'
+
+    # delete
+    resp = client.delete(f'/api/company-news/{note_id}')
+    assert resp.status_code == 200
+
+    # ensure empty again
+    resp = client.get('/api/company-news/ABCD')
+    assert resp.status_code == 200
+    assert resp.get_json()['notes'] == []


### PR DESCRIPTION
## Summary
- add CompanyNewsNote model to track company-specific news
- implement CRUD API and register new blueprint
- test company news endpoints for create/list/update/delete

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6899e188d7fc8327b0ac439a75b23cb0