### PR TITLE
Use JSON contains for news article tickers

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -154,7 +154,7 @@ class MarketArticle(db.Model):
     autor = db.Column(String(255))
     data_publicacao = db.Column(DateTime)
     categoria = db.Column(String(255))
-    tickers_relacionados = db.Column(Text)
+    tickers_relacionados = db.Column(JSON)
     score_impacto = db.Column(Numeric(10, 4))
 
     def to_dict(self):

--- a/backend/routes/news_routes.py
+++ b/backend/routes/news_routes.py
@@ -9,7 +9,7 @@ def get_news_by_ticker(ticker):
     ticker_upper = ticker.upper()
     articles = (
         MarketArticle.query
-        .filter(MarketArticle.tickers_relacionados.ilike(f"%{ticker_upper}%"))
+        .filter(MarketArticle.tickers_relacionados.contains([ticker_upper]))
         .order_by(MarketArticle.data_publicacao.desc())
         .all()
     )

--- a/test_news_routes.py
+++ b/test_news_routes.py
@@ -1,0 +1,16 @@
+import pytest
+from backend import db
+from backend.models import MarketArticle
+
+
+def test_get_news_by_ticker(client):
+    with client.application.app_context():
+        db.session.add(MarketArticle(titulo='Match', tickers_relacionados=['PETR4']))
+        db.session.add(MarketArticle(titulo='Other', tickers_relacionados=['VALE3']))
+        db.session.commit()
+
+    resp = client.get('/api/news/company/PETR4')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert len(data) == 1
+    assert data[0]['titulo'] == 'Match'


### PR DESCRIPTION
## Summary
- treat MarketArticle.tickers_relacionados as JSON
- query news by ticker using JSON array containment
- add test for /api/news/company/<ticker>

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6899e18897748327aa2a0ac1901a500d