### PR TITLE
Handle Gemini API key absence with fallback

### DIFF
--- a/.env
+++ b/.env
@@ -14,3 +14,7 @@ SECRET_KEY=
 MT5_LOGIN=
 MT5_PASSWORD=
 MT5_SERVER=
+
+# Google Gemini
+# Chave necessária para recursos de IA. Quando ausente, esses recursos são desativados.
+GEMINI_API_KEY=

--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ cp frontend/.env.example frontend/.env
 ```
 Atualize `frontend/.env` com as URLs da API e a chave do Gemini antes de iniciar o projeto.
 
+### Recursos de IA (Google Gemini)
+
+Os recursos de inteligência artificial utilizam a API do Google Gemini. Defina `GEMINI_API_KEY` no `.env` do backend e `VITE_GEMINI_API_KEY` no `.env` do frontend.
+
+Caso essa chave não seja fornecida, o sistema continuará funcionando, mas os recursos de IA exibirão avisos e retornarão mensagens de fallback em vez de respostas geradas.
+
 ## Executar Testes
 
 Backend:

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,1 +1,3 @@
 VITE_API_URL=http://localhost:5001
+# Necessária para recursos de IA. Quando não definida, mensagens de fallback serão exibidas.
+VITE_GEMINI_API_KEY=

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,4 +1,5 @@
 # Frontend environment variables example
 VITE_BACKEND_URL=http://localhost:5001/api
 VITE_API_URL=http://localhost:5001/api
-GEMINI_API_KEY=
+# Necessária para recursos de IA. Quando não definida, mensagens de fallback serão exibidas.
+VITE_GEMINI_API_KEY=

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -9,6 +9,6 @@ This contains everything you need to run your app locally.
 
 1. Install dependencies:
    `npm install`
-2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
+2. Set `VITE_GEMINI_API_KEY` in your `.env` file to your Gemini API key. Without it, AI features will emit warnings and return fallback responses.
 3. Run the app:
    `npm run dev`

--- a/frontend/services/geminiService.ts
+++ b/frontend/services/geminiService.ts
@@ -1,16 +1,21 @@
 import { GoogleGenAI } from "@google/genai";
 import { CompanyNewsItem } from '../types';
 
-const API_KEY = process.env.API_KEY;
+const API_KEY = import.meta.env.VITE_GEMINI_API_KEY as string | undefined;
 
 if (!API_KEY) {
-    throw new Error("API_KEY environment variable not set.");
+    console.warn("GEMINI_API_KEY não definida. Recursos de IA estão desativados.");
 }
 
-const ai = new GoogleGenAI({ apiKey: API_KEY });
+const ai = API_KEY ? new GoogleGenAI({ apiKey: API_KEY }) : null;
 const model = 'gemini-2.5-flash';
 
 const streamFinancialAnalysis = async function* (prompt: string, systemInstruction: string) {
+    if (!ai) {
+        yield "Recurso de IA indisponível. Defina GEMINI_API_KEY para habilitar.";
+        return;
+    }
+
     try {
         const result = await ai.models.generateContentStream({
             model: model,


### PR DESCRIPTION
## Summary
- Warn instead of throwing when `GEMINI_API_KEY` is missing and use `import.meta.env.VITE_GEMINI_API_KEY`
- Document Gemini API key usage and fallback behaviour in env files and README

## Testing
- `pytest -q` *(fails: test_create_note_without_content)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899e7fdd10c8327a5d2bfe13a80bcb5