### PR TITLE
feat: add portfolio positions saving

### DIFF
--- a/frontend/components/PortfolioManager.tsx
+++ b/frontend/components/PortfolioManager.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { EditableAsset, DailyMetric } from '../types';
 import { ChevronUpIcon, PencilSquareIcon, TrashIcon, PlusIcon } from '../constants';
+import { upsertPositions } from '../services/portfolioApi';
 
 interface PortfolioManagerProps {
     initialAssets?: EditableAsset[];
@@ -52,6 +53,20 @@ const PortfolioManager: React.FC<PortfolioManagerProps> = ({ initialAssets = [] 
             }
             const newValue = parseFloat((metric.value + amount).toFixed(precision));
             handleMetricChange(id, newValue);
+        }
+    };
+
+    const handleSavePortfolio = async () => {
+        try {
+            await upsertPositions(1, assets.map(a => ({
+                symbol: a.ticker,
+                quantity: a.quantity,
+                avg_price: (a as any).price ?? 0,
+            })));
+            alert('Carteira salva com sucesso!');
+        } catch (error) {
+            console.error(error);
+            alert('Erro ao salvar carteira');
         }
     };
     
@@ -120,7 +135,7 @@ const PortfolioManager: React.FC<PortfolioManagerProps> = ({ initialAssets = [] 
                         <button onClick={handleAddAsset} className="flex items-center gap-1 text-sm text-sky-400 hover:text-sky-300">
                            <PlusIcon className="w-4 h-4" /> Adicionar Ativo
                         </button>
-                        <button onClick={() => console.log('Saving assets:', assets)} className="bg-sky-600 text-white px-4 py-2 rounded-md text-sm font-semibold hover:bg-sky-500">
+                        <button onClick={handleSavePortfolio} className="bg-sky-600 text-white px-4 py-2 rounded-md text-sm font-semibold hover:bg-sky-500">
                             Salvar Carteira
                         </button>
                     </div>

--- a/frontend/services/portfolioApi.ts
+++ b/frontend/services/portfolioApi.ts
@@ -18,6 +18,20 @@ export async function savePortfolioSnapshot(id: number): Promise<void> {
   }
 }
 
+export async function upsertPositions(
+  id: number,
+  positions: { symbol: string; quantity: number; avg_price: number }[],
+): Promise<void> {
+  const res = await fetch(`${API_BASE}/portfolio/${id}/positions`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(positions),
+  });
+  if (!res.ok) {
+    throw new Error('Falha ao salvar posições');
+  }
+}
+
 export async function getPortfolioDailyValues(id: number): Promise<PortfolioDailyValue[]> {
   const res = await fetch(`${API_BASE}/portfolio/${id}/daily-values`);
   if (!res.ok) {
@@ -29,6 +43,7 @@ export async function getPortfolioDailyValues(id: number): Promise<PortfolioDail
 export const portfolioApi = {
   getPortfolioSummary,
   savePortfolioSnapshot,
+  upsertPositions,
   getPortfolioDailyValues,
 };
 


### PR DESCRIPTION
## Summary
- add upsertPositions API call for saving portfolio holdings
- use upsertPositions in PortfolioManager with user feedback

## Testing
- `npm test`
- `pytest` *(fails: assert 400 == 201)*

------
https://chatgpt.com/codex/tasks/task_e_6899e99df5b88327bcb3833e3dfa60f9