### PR TITLE
refactor: avoid double json parsing

### DIFF
--- a/frontend/components/Research.tsx
+++ b/frontend/components/Research.tsx
@@ -14,13 +14,11 @@ const Research: React.FC = () => {
             try {
                 const res = await fetch('/api/research/notes');
                 if (res.ok) {
-                    const json = await res.json();
-                    const data: ResearchNote[] = json.notes;
-                    setNotes(data);
-                    setActiveNoteId(data[0]?.id ?? null);
                     const { notes } = await res.json();
                     setNotes(notes);
                     setActiveNoteId(notes[0]?.id ?? null);
+                } else {
+                    console.error('Falha ao carregar notas', await res.text());
                 }
             } catch (err) {
                 console.error('Failed to load notes', err);


### PR DESCRIPTION
## Summary
- avoid double JSON parsing in research note loader

## Testing
- `npm test`
- `pytest` *(fails: test_create_note_without_content expected 201 but got 400)*

------
https://chatgpt.com/codex/tasks/task_e_6899ea5db4e48327adf0a981ab41af29