### PR TITLE
feat: handle note creation errors

### DIFF
--- a/frontend/components/Research.tsx
+++ b/frontend/components/Research.tsx
@@ -37,10 +37,12 @@ const Research: React.FC = () => {
                 body: JSON.stringify({ title: 'Nova Anotação', summary: '', content: '' })
             });
             if (res.ok) {
-                const json = await res.json();
-                const newNote: ResearchNote = json.note;
-                setNotes(prev => [newNote, ...prev]);
-                setActiveNoteId(newNote.id);
+                const { note } = await res.json();
+                setNotes(prev => [note, ...prev]);
+                setActiveNoteId(note.id);
+            } else {
+                console.error('Erro ao criar nota', await res.text());
+                alert('Não foi possível criar a nota. Verifique o backend.');
             }
         } catch (err) {
             console.error('Failed to create note', err);


### PR DESCRIPTION
## Summary
- show error alert if creating a note fails

## Testing
- `npm test`
- `pytest` *(fails: assert 400 == 201 in test_create_note_without_content)*

------
https://chatgpt.com/codex/tasks/task_e_6899ea5ee6e08327b489c96b3baca993