### PR TITLE
docs: explain Gemini API key fallback

### DIFF
--- a/.env
+++ b/.env
@@ -16,5 +16,5 @@ MT5_PASSWORD=
 MT5_SERVER=
 
 # Google Gemini
-# Chave necessária para recursos de IA. Quando ausente, esses recursos são desativados.
+# Chave necessária para recursos de IA. Quando ausente, os serviços exibem avisos e retornam respostas de fallback.
 GEMINI_API_KEY=

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Atualize `frontend/.env` com as URLs da API e a chave do Gemini antes de iniciar
 
 Os recursos de inteligência artificial utilizam a API do Google Gemini. Defina `GEMINI_API_KEY` no `.env` do backend e `VITE_GEMINI_API_KEY` no `.env` do frontend.
 
-Caso essa chave não seja fornecida, o sistema continuará funcionando, mas os recursos de IA exibirão avisos e retornarão mensagens de fallback em vez de respostas geradas.
+Caso essa chave não seja fornecida, o sistema continuará funcionando, mas o `geminiService` registrará um `console.warn` e retornará mensagens de fallback em vez de respostas geradas.
 
 ## Executar Testes
 

--- a/frontend/services/geminiService.ts
+++ b/frontend/services/geminiService.ts
@@ -1,6 +1,7 @@
 import { GoogleGenAI } from "@google/genai";
 import { CompanyNewsItem } from '../types';
 
+// Retrieve the key from Vite's runtime env to avoid depending on `process.env` in the browser.
 const API_KEY = import.meta.env.VITE_GEMINI_API_KEY as string | undefined;
 
 if (!API_KEY) {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,13 +1,8 @@
 import path from 'path';
-import { defineConfig, loadEnv } from 'vite';
+import { defineConfig } from 'vite';
 
-export default defineConfig(({ mode }) => {
-    const env = loadEnv(mode, '.', '');
+export default defineConfig(() => {
     return {
-      define: {
-        'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
-        'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY)
-      },
       resolve: {
         alias: {
           '@': path.resolve(__dirname, '.'),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,13 +1,8 @@
 import path from 'path';
-import { defineConfig, loadEnv } from 'vite';
+import { defineConfig } from 'vite';
 
-export default defineConfig(({ mode }) => {
-    const env = loadEnv(mode, '.', '');
+export default defineConfig(() => {
     return {
-      define: {
-        'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
-        'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY)
-      },
       resolve: {
         alias: {
           '@': path.resolve(__dirname, '.'),


### PR DESCRIPTION
## Summary
- document console warnings and fallback responses when GEMINI_API_KEY is missing
- use import.meta.env and drop process.env injections in Vite configs

## Testing
- `npm test`
- `pytest -q` *(fails: test_create_note_without_content)*

------
https://chatgpt.com/codex/tasks/task_e_6899ec197b9c8327b8f4d0af5ed5bff4