### PR TITLE
chore: update proxy target port

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,7 +12,7 @@ export default defineConfig(() => {
         port: 5173, // Define a porta do frontend explicitamente
         proxy: {
           '/api': {
-            target: 'http://127.0.0.1:5000',
+            target: 'http://127.0.0.1:5001',
             changeOrigin: true,
             secure: false, // Frequentemente ajuda a resolver problemas de proxy
             // Adiciona logs para depurar o que o proxy está fazendo


### PR DESCRIPTION
## Summary
- point Vite dev server proxy to backend on port 5001

## Testing
- `npm test` *(fails: Cannot read properties of undefined (reading 'getIndicators'))*
- `pytest` *(fails: assert 500 == 200; assert 201 == 400)*
- `npx vite`
- `python run_backend.py` *(fails: OperationalError: connection to server on socket "/var/run/postgresql/.s.PGSQL.5432" failed: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6899f385e56483279ae6834863b7ecb9