### PR TITLE
Add summary field for market news and enhance news service

### DIFF
--- a/frontend/services/newsService.ts
+++ b/frontend/services/newsService.ts
@@ -17,7 +17,7 @@ export const getCompanyNews = async (
     summary: item.resumo,
     source: item.portal,
     publishedDate: item.data_publicacao,
-    url: item.link_url,
+    url: item.link_url || item.url,
   }));
 };
 
@@ -35,8 +35,9 @@ export const getLatestNews = async (
     headline: item.titulo,
     source: item.portal,
     timestamp: item.data_publicacao,
-    content: item.resumo,
-    url: item.link_url,
+    summary: item.resumo,
+    content: item.conteudo_completo || item.resumo,
+    url: item.link_url || item.url,
     imageUrl: item.imagem_url || item.image_url,
     tags: item.tags,
     aiAnalysis: item.aiAnalysis,

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -92,6 +92,7 @@ export interface MarketNewsArticle {
     headline: string;
     source: string;
     timestamp: string;
+    summary: string;
     content: string;
     url: string;
     imageUrl?: string;


### PR DESCRIPTION
## Summary
- add `summary` attribute to `MarketNewsArticle`
- return both `summary` and full `content` in latest news mapping
- ensure `url` is consistently mapped in company and market news services

## Testing
- `npm test` *(fails: macroService tests: TypeError Cannot read properties of undefined (reading 'getIndicators'))*

------
https://chatgpt.com/codex/tasks/task_e_6899f3d7dec083279c9d5add9d8e4d2a