### PR TITLE
feat: add AI news analysis endpoint

### DIFF
--- a/frontend/services/newsService.ts
+++ b/frontend/services/newsService.ts
@@ -43,5 +43,17 @@ export const getLatestNews = async (
   }));
 };
 
-export const newsService = { getCompanyNews, getLatestNews };
+export const analyzeNews = async (
+  id: number
+): Promise<any> => {
+  const res = await fetch(`${API_BASE}/news/${id}/analyze`, {
+    method: 'POST',
+  });
+  if (!res.ok) {
+    throw new Error('Falha ao analisar notícia');
+  }
+  return res.json();
+};
+
+export const newsService = { getCompanyNews, getLatestNews, analyzeNews };
 

--- a/test_news_routes.py
+++ b/test_news_routes.py
@@ -14,3 +14,17 @@ def test_get_news_by_ticker(client):
     data = resp.get_json()
     assert len(data) == 1
     assert data[0]['titulo'] == 'Match'
+
+
+def test_analyze_news(client):
+    with client.application.app_context():
+        article = MarketArticle(titulo='Test', resumo='Boa notícia', tickers_relacionados=[])
+        db.session.add(article)
+        db.session.commit()
+        art_id = article.id
+
+    resp = client.post(f'/api/news/{art_id}/analyze')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert 'sentiment' in data
+    assert 'summary' in data


### PR DESCRIPTION
## Summary
- load and display AI analysis for market news items
- expose POST /api/news/<id>/analyze endpoint with basic sentiment analysis
- simplify MarketNews UI when analysis is absent

## Testing
- `npm test` *(fails: TypeError: Cannot read properties of undefined (reading 'getIndicators'))*
- `pytest` *(fails: test_macro_routes.py::test_get_macro_indicators - assert 500 == 200)*

------
https://chatgpt.com/codex/tasks/task_e_6899f3f8cfd08327bf0cf9f3c207941e