### PR TITLE
feat: reload portfolio summary after saving positions

### DIFF
--- a/frontend/components/PortfolioDashboard.tsx
+++ b/frontend/components/PortfolioDashboard.tsx
@@ -7,17 +7,18 @@ const PortfolioDashboard: React.FC = () => {
   const [portfolio, setPortfolio] = useState<PortfolioSummary | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    async function load() {
-      try {
-        const data = await portfolioApi.getPortfolioSummary(1);
-        setPortfolio(data);
-      } catch (err) {
-        console.error(err);
-        setError('Erro ao carregar portfólio');
-      }
+  const loadSummary = async () => {
+    try {
+      const data = await portfolioApi.getPortfolioSummary(1);
+      setPortfolio(data);
+    } catch (err) {
+      console.error(err);
+      setError('Erro ao carregar portfólio');
     }
-    load();
+  };
+
+  useEffect(() => {
+    loadSummary();
   }, []);
 
   const holdings = portfolio?.holdings ?? [];
@@ -31,6 +32,7 @@ const PortfolioDashboard: React.FC = () => {
           quantity: h.quantity,
           targetWeight: 0,
         }))}
+        onSaved={loadSummary}
       />
 
       {error && <p className="text-red-400">{error}</p>}

--- a/frontend/components/PortfolioManager.tsx
+++ b/frontend/components/PortfolioManager.tsx
@@ -5,6 +5,7 @@ import { upsertPositions } from '../services/portfolioApi';
 
 interface PortfolioManagerProps {
     initialAssets?: EditableAsset[];
+    onSaved?: () => void;
 }
 
 const initialMetrics: DailyMetric[] = [
@@ -15,7 +16,7 @@ const initialMetrics: DailyMetric[] = [
     { id: 'outrasDespesas', label: 'Outras Despesas', value: 0.00 },
 ];
 
-const PortfolioManager: React.FC<PortfolioManagerProps> = ({ initialAssets = [] }) => {
+const PortfolioManager: React.FC<PortfolioManagerProps> = ({ initialAssets = [], onSaved }) => {
     const [isOpen, setIsOpen] = useState(false);
     const [assets, setAssets] = useState<EditableAsset[]>(initialAssets);
     const [metrics, setMetrics] = useState<DailyMetric[]>(initialMetrics);
@@ -63,6 +64,7 @@ const PortfolioManager: React.FC<PortfolioManagerProps> = ({ initialAssets = [] 
                 quantity: a.quantity,
                 avg_price: (a as any).price ?? 0,
             })));
+            onSaved?.();
             alert('Carteira salva com sucesso!');
         } catch (error) {
             console.error(error);


### PR DESCRIPTION
## Summary
- reload dashboard summary when portfolio positions are saved
- notify parent component after persisting positions

## Testing
- `npm test` *(fails: TypeError: Cannot read properties of undefined)*

------
https://chatgpt.com/codex/tasks/task_e_6899fd05c3dc8327af457cb463deb39a