### PR TITLE
refactor: rename news headline to title

### DIFF
--- a/frontend/components/MarketNews.tsx
+++ b/frontend/components/MarketNews.tsx
@@ -60,7 +60,7 @@ const MarketNews: React.FC = () => {
                                 selectedArticle?.id === news.id ? 'bg-slate-700' : 'hover:bg-slate-700/50'
                             }`}
                         >
-                            <p className="text-sm font-semibold text-white leading-tight">{news.headline}</p>
+                            <p className="text-sm font-semibold text-white leading-tight">{news.title}</p>
                             <p className="text-xs text-slate-400 mt-1">{news.summary}</p>
                             <div className="flex items-center justify-between mt-1.5">
                                 <span className="text-xs text-slate-400">{news.source.toUpperCase()}</span>
@@ -80,7 +80,7 @@ const MarketNews: React.FC = () => {
                     <>
                         <div className="flex justify-between items-start mb-4">
                             <div>
-                                <h1 className="text-2xl font-bold text-white">{selectedArticle.headline}</h1>
+                                <h1 className="text-2xl font-bold text-white">{selectedArticle.title}</h1>
                                 <p className="text-sm text-slate-400 mt-1">{selectedArticle.timestamp} • {selectedArticle.source}</p>
                             </div>
                             <button onClick={() => setSelectedArticle(newsArticles[0] || null)} className="p-1 text-slate-400 hover:text-white rounded-full hover:bg-slate-700">
@@ -90,7 +90,7 @@ const MarketNews: React.FC = () => {
                         {selectedArticle.imageUrl && (
                             <img
                                 src={selectedArticle.imageUrl}
-                                alt={selectedArticle.headline}
+                                alt={selectedArticle.title}
                                 className="w-full h-64 object-cover rounded-lg mb-4"
                             />
                         )}

--- a/frontend/services/newsService.ts
+++ b/frontend/services/newsService.ts
@@ -32,7 +32,7 @@ export const getLatestNews = async (
   const items = (json.news || json.data || json) as any[];
   return items.map((item: any, idx: number) => ({
     id: Number(item.id ?? idx),
-    headline: item.titulo,
+    title: item.titulo,
     source: item.portal,
     timestamp: item.data_publicacao,
     summary: item.resumo,

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -89,7 +89,7 @@ export interface AiAnalysis {
 
 export interface MarketNewsArticle {
     id: number;
-    headline: string;
+    title: string;
     source: string;
     timestamp: string;
     summary: string;


### PR DESCRIPTION
## Summary
- rename MarketNewsArticle.headline to title
- map API field `titulo` to `title`
- adjust MarketNews component to use `title`

## Testing
- `npm test` *(fails: Cannot read properties of undefined (reading 'getIndicators'))*
- `PYTHONDONTWRITEBYTECODE=1 pytest -q` *(fails: assert 500 == 200; assert 201 == 400)*

------
https://chatgpt.com/codex/tasks/task_e_689a0084c4d48327bf9df6c0d259aff3