### PR TITLE
feat: add portal filter for market news

### DIFF
--- a/backend/routes/news_routes.py
+++ b/backend/routes/news_routes.py
@@ -20,8 +20,12 @@ def get_news_by_ticker(ticker):
 @news_bp.route('/latest', methods=['GET'])
 def get_latest_news():
     limit = request.args.get('limit', 10, type=int)
+    portal = request.args.get('portal')
+    query = MarketArticle.query
+    if portal:
+        query = query.filter(MarketArticle.portal == portal)
     articles = (
-        MarketArticle.query
+        query
         .order_by(MarketArticle.data_publicacao.desc())
         .limit(limit)
         .all()

--- a/frontend/components/MarketNews.tsx
+++ b/frontend/components/MarketNews.tsx
@@ -1,5 +1,5 @@
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { MarketNewsArticle } from '../types';
 import { StarIcon, CurrencyDollarIcon, XMarkIcon, ArrowRightIcon } from '../constants';
 import { newsService } from '../services/newsService';
@@ -7,6 +7,9 @@ const MarketNews: React.FC = () => {
     const [activeTab, setActiveTab] = useState('Últimas');
     const [newsArticles, setNewsArticles] = useState<MarketNewsArticle[]>([]);
     const [selectedArticle, setSelectedArticle] = useState<MarketNewsArticle | null>(null);
+    const [portalFilter, setPortalFilter] = useState('');
+
+    const portals = useMemo(() => Array.from(new Set(newsArticles.map(n => n.source))), [newsArticles]);
 
     const handleSelectArticle = async (article: MarketNewsArticle) => {
         setSelectedArticle(article);
@@ -50,9 +53,21 @@ const MarketNews: React.FC = () => {
                             <CurrencyDollarIcon /> Cripto
                         </button>
                     </div>
+                    <select
+                        value={portalFilter}
+                        onChange={(e) => setPortalFilter(e.target.value)}
+                        className="bg-slate-800 text-slate-300 text-sm rounded-md border border-slate-700 px-2 py-1"
+                    >
+                        <option value="">Todos</option>
+                        {portals.map(portal => (
+                            <option key={portal} value={portal}>{portal.toUpperCase()}</option>
+                        ))}
+                    </select>
                 </div>
                 <div className="flex-grow overflow-y-auto pr-1">
-                    {newsArticles.map(news => (
+                    {newsArticles
+                        .filter(n => !portalFilter || n.source === portalFilter)
+                        .map(news => (
                         <div
                             key={news.id}
                             onClick={() => setSelectedArticle(news)}

--- a/frontend/services/newsService.ts
+++ b/frontend/services/newsService.ts
@@ -22,9 +22,14 @@ export const getCompanyNews = async (
 };
 
 export const getLatestNews = async (
-  limit = 10
+  limit = 10,
+  portal?: string
 ): Promise<MarketNewsArticle[]> => {
-  const res = await fetch(`${API_BASE}/news/latest?limit=${limit}`);
+  const params = new URLSearchParams({ limit: String(limit) });
+  if (portal) {
+    params.append('portal', portal);
+  }
+  const res = await fetch(`${API_BASE}/news/latest?${params.toString()}`);
   if (!res.ok) {
     throw new Error('Falha ao buscar últimas notícias');
   }

--- a/test_news_routes.py
+++ b/test_news_routes.py
@@ -28,3 +28,16 @@ def test_analyze_news(client):
     data = resp.get_json()
     assert 'sentiment' in data
     assert 'summary' in data
+
+
+def test_get_latest_news_portal_filter(client):
+    with client.application.app_context():
+        db.session.add(MarketArticle(titulo='A', portal='PortalA', tickers_relacionados=[]))
+        db.session.add(MarketArticle(titulo='B', portal='PortalB', tickers_relacionados=[]))
+        db.session.commit()
+
+    resp = client.get('/api/news/latest?portal=PortalA')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert len(data) == 1
+    assert data[0]['portal'] == 'PortalA'


### PR DESCRIPTION
## Summary
- allow filtering market news by source portal in UI
- expose optional `portal` parameter in `/api/news/latest`
- cover news filtering with backend test

## Testing
- `npm test` *(fails: TypeError: Cannot read properties of undefined (reading 'getIndicators'))*
- `pytest test_news_routes.py`

------
https://chatgpt.com/codex/tasks/task_e_689a009def008327aa9367ef049334db