### PR TITLE
Run Alembic migrations on backend startup

### DIFF
--- a/INTEGRACAO_METATRADER5.md
+++ b/INTEGRACAO_METATRADER5.md
@@ -98,6 +98,8 @@ python3 run_backend_mt5.py
 # Ou usar script original (detecta MT5 automaticamente)
 python3 run_backend.py
 ```
+Ao executar `run_backend.py`, as migrações do banco de dados são aplicadas automaticamente
+para manter o schema atualizado.
 
 ### 4. **Verificar Funcionamento**
 
@@ -309,4 +311,6 @@ python3 run_backend_mt5.py
 ```bash
 python3 run_backend.py
 ```
+Esse comando também aplica automaticamente as migrações do Alembic,
+mantendo o banco na última versão.
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ Backend (terminal 1):
 ```bash
 python run_backend.py
 ```
+Ao iniciar por esse comando, as migrações do banco de dados são aplicadas automaticamente,
+garantindo que o schema esteja sempre atualizado.
 
 Frontend (terminal 2):
 ```bash

--- a/run_backend.py
+++ b/run_backend.py
@@ -9,6 +9,8 @@ import sys
 import logging
 from dotenv import load_dotenv
 from sqlalchemy import text
+from alembic import command
+from alembic.config import Config
 from backend.services.rtd_worker_integration import integrate_rtd_worker
 
 # Carregar .env ANTES de tudo
@@ -68,6 +70,13 @@ def main():
         
         # Inicializar database
         with app.app_context():
+            try:
+                alembic_cfg = Config(os.path.join(os.path.dirname(__file__), 'alembic.ini'))
+                command.upgrade(alembic_cfg, 'head')
+                logger.info("✅ Migrações aplicadas com sucesso")
+            except Exception as e:
+                logger.error(f"❌ Falha ao aplicar migrações: {e}")
+
             # Testar conexão PostgreSQL
             try:
                 db.session.execute(text('SELECT 1'))


### PR DESCRIPTION
## Summary
- Apply Alembic migrations automatically before the Flask server starts.
- Document that `run_backend.py` upgrades the database schema on launch.
- Clarify automatic migration behaviour in the MetaTrader5 integration guide.

## Testing
- `pytest -q` *(fails: test_get_macro_indicators, test_create_note_without_content)*

------
https://chatgpt.com/codex/tasks/task_e_689a0305d5f483278f908ba241a700ff