### PR TITLE
Add structured logging and document config

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,23 @@ Os recursos de inteligência artificial utilizam a API do Google Gemini. Defina 
 
 Caso essa chave não seja fornecida, o sistema continuará funcionando, mas o `geminiService` registrará um `console.warn` e retornará mensagens de fallback em vez de respostas geradas.
 
+### Sistema de Logs e Alertas
+
+O backend grava erros em arquivo e pode enviar exceções para serviços externos como o Sentry. As principais variáveis de ambiente são:
+
+```bash
+# Caminho do arquivo de log (padrão: logs/backend.log)
+export LOG_FILE=/caminho/para/backend.log
+
+# Nível de log (padrão: INFO)
+export LOG_LEVEL=DEBUG
+
+# DSN do Sentry para captura de exceções (opcional)
+export SENTRY_DSN=https://exemplo@sentry.io/123
+```
+
+Com `LOG_FILE` definido, todas as exceções — incluindo erros de banco de dados capturados pelo SQLAlchemy — serão registradas no arquivo especificado. Caso `SENTRY_DSN` esteja configurado e o pacote `sentry-sdk` instalado, as exceções também serão enviadas ao Sentry para monitoramento.
+
 ## Executar Testes
 
 Backend:

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -5,16 +5,62 @@ from flask_socketio import SocketIO
 from flask_migrate import Migrate
 from sqlalchemy import text
 from .config import Config
+import logging
+import os
+
+
+def setup_logging():
+    """Configure logging for the application.
+
+    Creates a file handler and integrates with Sentry (if available).
+    """
+    log_level = os.environ.get("LOG_LEVEL", "INFO").upper()
+    log_file = os.environ.get("LOG_FILE", "logs/backend.log")
+    os.makedirs(os.path.dirname(log_file), exist_ok=True)
+
+    formatter = logging.Formatter(
+        "%(asctime)s [%(levelname)s] %(name)s - %(message)s"
+    )
+
+    file_handler = logging.FileHandler(log_file)
+    file_handler.setLevel(log_level)
+    file_handler.setFormatter(formatter)
+
+    root_logger = logging.getLogger()
+    root_logger.setLevel(log_level)
+    root_logger.addHandler(file_handler)
+
+    # Ensure SQLAlchemy errors are also captured
+    sqlalchemy_logger = logging.getLogger("sqlalchemy")
+    sqlalchemy_logger.setLevel(logging.ERROR)
+
+    sentry_dsn = os.environ.get("SENTRY_DSN")
+    if sentry_dsn:
+        try:
+            import sentry_sdk
+            from sentry_sdk.integrations.flask import FlaskIntegration
+            from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
+
+            sentry_sdk.init(
+                dsn=sentry_dsn,
+                integrations=[FlaskIntegration(), SqlalchemyIntegration()],
+            )
+        except ImportError:
+            root_logger.warning(
+                "sentry-sdk não instalado. Ignorando integração com Sentry."
+            )
 
 db = SQLAlchemy()
 socketio = SocketIO()
 migrate = Migrate()
 
 def create_app():
+    setup_logging()
+
     app = Flask(__name__)
     CORS(app, resources={r"/api/*": {"origins": "*"}})
     app.config.from_object(Config)
-    
+
     db.init_app(app)
     migrate.init_app(app, db)
     socketio.init_app(app, cors_allowed_origins="*")

--- a/backend/routes/documents_routes.py
+++ b/backend/routes/documents_routes.py
@@ -40,7 +40,7 @@ def get_documents_by_company_id(company_id):
             "documents": doc_list,
         })
     except Exception as e:
-        logger.error(f"Erro em get_documents_by_company_id: {e}")
+        logger.exception(f"Erro em get_documents_by_company_id: {e}")
         return jsonify({"success": False, "error": "Erro interno ao buscar documentos"}), 500
 
 
@@ -68,7 +68,7 @@ def list_cvm_documents():
         ]
         return jsonify({"success": True, "documents": documents})
     except Exception as e:
-        logger.error(f"Erro em list_cvm_documents: {e}")
+        logger.exception(f"Erro em list_cvm_documents: {e}")
         return jsonify({"success": False, "error": "Erro ao listar documentos"}), 500
 
 
@@ -88,7 +88,7 @@ def list_document_types():
         ]
         return jsonify({"success": True, "document_types": document_types})
     except Exception as e:
-        logger.error(f"Erro em list_document_types: {e}")
+        logger.exception(f"Erro em list_document_types: {e}")
         return jsonify({"success": False, "error": "Erro ao listar tipos"}), 500
 
 
@@ -110,5 +110,5 @@ def list_cvm_companies():
         ]
         return jsonify({"companies": company_list})
     except Exception as e:
-        logger.error(f"Erro em list_cvm_companies: {e}")
+        logger.exception(f"Erro em list_cvm_companies: {e}")
         return jsonify({"error": "Erro ao listar empresas"}), 500


### PR DESCRIPTION
## Summary
- log full stack traces in document routes
- add file-based logging and optional Sentry integration
- document log and alert configuration variables

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a0524b8908327a57ae8d9cc28e4c1