### PR TITLE
Ensure UTF-8 logging output

### DIFF
--- a/backend/bulk_mt5_scraper.py
+++ b/backend/bulk_mt5_scraper.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import time
 import pandas as pd
 import MetaTrader5 as mt5
@@ -7,8 +8,13 @@ from dotenv import load_dotenv
 from tqdm import tqdm
 import logging
 
-# --- 1. CONFIGURAÇÃO ---
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+if sys.stdout.encoding.lower() != "utf-8":
+    sys.stdout.reconfigure(encoding="utf-8")
+    sys.stderr.reconfigure(encoding="utf-8")
+
+handler = logging.StreamHandler(sys.stdout)
+handler.setFormatter(logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s'))
+logging.basicConfig(level=logging.INFO, handlers=[handler], force=True)
 load_dotenv()
 
 def get_db_engine():

--- a/backend/services/metatrader5_rtd_worker.py
+++ b/backend/services/metatrader5_rtd_worker.py
@@ -13,8 +13,13 @@ import pandas as pd
 from sqlalchemy import create_engine, text
 from dotenv import load_dotenv
 
-# Configurar logging para um nível mais detalhado para depuração
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+if sys.stdout.encoding.lower() != "utf-8":
+    sys.stdout.reconfigure(encoding="utf-8")
+    sys.stderr.reconfigure(encoding="utf-8")
+
+handler = logging.StreamHandler(sys.stdout)
+handler.setFormatter(logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s'))
+logging.basicConfig(level=logging.INFO, handlers=[handler], force=True)
 logger = logging.getLogger(__name__)
 
 try:

--- a/dados_financeiros/financials_scraper_user.py
+++ b/dados_financeiros/financials_scraper_user.py
@@ -11,8 +11,15 @@ from typing import Dict, List, Optional
 from playwright.sync_api import sync_playwright
 import logging
 import numpy as np
+import sys
 
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+if sys.stdout.encoding.lower() != "utf-8":
+    sys.stdout.reconfigure(encoding="utf-8")
+    sys.stderr.reconfigure(encoding="utf-8")
+
+handler = logging.StreamHandler(sys.stdout)
+handler.setFormatter(logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s'))
+logging.basicConfig(level=logging.INFO, handlers=[handler], force=True)
 
 def get_cvm_code_as_int(identifier: str) -> Optional[int]:
     if not identifier: return None

--- a/run.py
+++ b/run.py
@@ -1,12 +1,18 @@
 import os
+import sys
 import logging
 from flask_socketio import SocketIO
 from backend import create_app, socketio
 from backend.services.metatrader5_rtd_worker import initialize_rtd_worker
 from backend.routes.realtime_routes import register_socketio_events
 
-# Configurar o logging
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+if sys.stdout.encoding.lower() != "utf-8":
+    sys.stdout.reconfigure(encoding="utf-8")
+    sys.stderr.reconfigure(encoding="utf-8")
+
+handler = logging.StreamHandler(sys.stdout)
+handler.setFormatter(logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s'))
+logging.basicConfig(level=logging.INFO, handlers=[handler], force=True)
 logger = logging.getLogger(__name__)
 
 # --- INICIALIZAÇÃO DA APLICAÇÃO ---

--- a/run_backend.py
+++ b/run_backend.py
@@ -13,15 +13,17 @@ from alembic import command
 from alembic.config import Config
 from backend.services.rtd_worker_integration import integrate_rtd_worker
 
+if sys.stdout.encoding.lower() != "utf-8":
+    sys.stdout.reconfigure(encoding="utf-8")
+    sys.stderr.reconfigure(encoding="utf-8")
+
+handler = logging.StreamHandler(sys.stdout)
+handler.setFormatter(logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s'))
+logging.basicConfig(level=logging.INFO, handlers=[handler], force=True)
+logger = logging.getLogger(__name__)
+
 # Carregar .env ANTES de tudo
 load_dotenv()
-
-# Configurar logging
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
-)
-logger = logging.getLogger(__name__)
 
 def main():
     logger.info("=" * 60)

--- a/run_backend_mt5.py
+++ b/run_backend_mt5.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import logging
 from flask import Flask, jsonify, request
 from flask_cors import CORS
@@ -8,8 +9,13 @@ from flask_socketio import SocketIO
 from dotenv import load_dotenv
 load_dotenv()  # Carrega variáveis do arquivo .env
 
-# --- Configuração do Logging ---
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+if sys.stdout.encoding.lower() != "utf-8":
+    sys.stdout.reconfigure(encoding="utf-8")
+    sys.stderr.reconfigure(encoding="utf-8")
+
+handler = logging.StreamHandler(sys.stdout)
+handler.setFormatter(logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s'))
+logging.basicConfig(level=logging.INFO, handlers=[handler], force=True)
 logger = logging.getLogger(__name__)
 
 # --- Factory Function para a Aplicação ---

--- a/scraper/database.py
+++ b/scraper/database.py
@@ -4,9 +4,15 @@ from sqlalchemy.orm import sessionmaker
 from contextlib import contextmanager
 from scraper.config import DATABASE_URL
 import logging
+import sys
 
-# Configura o logging
-logging.basicConfig(level=logging.INFO)
+if sys.stdout.encoding.lower() != "utf-8":
+    sys.stdout.reconfigure(encoding="utf-8")
+    sys.stderr.reconfigure(encoding="utf-8")
+
+handler = logging.StreamHandler(sys.stdout)
+handler.setFormatter(logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s'))
+logging.basicConfig(level=logging.INFO, handlers=[handler], force=True)
 logger = logging.getLogger(__name__)
 
 try:


### PR DESCRIPTION
## Summary
- enforce UTF-8 stdout/stderr and standardized StreamHandler logging
- apply configuration to backend entrypoints and MT5 worker modules

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a0d47c8948327b62246eedc7acbf9