### PR TITLE
feat: add filters to CVM documents endpoints

### DIFF
--- a/backend/routes/documents_routes.py
+++ b/backend/routes/documents_routes.py
@@ -2,6 +2,7 @@ from flask import Blueprint, jsonify, request
 from backend.models import CvmDocument, Company
 from backend import db
 import logging
+from datetime import datetime
 
 logger = logging.getLogger(__name__)
 documents_bp = Blueprint('documents_bp', __name__)
@@ -12,12 +13,25 @@ def get_documents_by_company_id(company_id):
     """Retorna os documentos CVM para um ID de empresa específico, usando o modelo correto."""
     try:
         limit = request.args.get('limit', 25, type=int)
-        
+        doc_type = request.args.get('document_type')
+        start_str = request.args.get('start_date')
+        end_str = request.args.get('end_date')
+
         company = db.session.get(Company, company_id)
         if not company:
-             return jsonify({"success": False, "message": f"Empresa com ID {company_id} não encontrada"}), 404
+            return jsonify({"success": False, "message": f"Empresa com ID {company_id} não encontrada"}), 404
 
-        docs = db.session.query(CvmDocument).with_parent(company).order_by(CvmDocument.delivery_date.desc()).limit(limit).all()
+        query = db.session.query(CvmDocument).filter(CvmDocument.company_id == company_id)
+        if doc_type:
+            query = query.filter(CvmDocument.document_type == doc_type)
+        if start_str:
+            start_date = datetime.strptime(start_str, "%Y-%m-%d")
+            query = query.filter(CvmDocument.delivery_date >= start_date)
+        if end_str:
+            end_date = datetime.strptime(end_str, "%Y-%m-%d")
+            query = query.filter(CvmDocument.delivery_date <= end_date)
+
+        docs = query.order_by(CvmDocument.delivery_date.desc()).limit(limit).all()
 
         if not docs:
             return jsonify({"success": True, "documents": [], "total": 0})
@@ -47,14 +61,29 @@ def get_documents_by_company_id(company_id):
 @cvm_bp.route('/documents', methods=['GET'])
 def list_cvm_documents():
     """Retorna uma lista simplificada de documentos da CVM."""
-    doc_type = request.args.get('document_type')
-    limit = request.args.get('limit', 100, type=int)
-
     try:
+        doc_type = request.args.get('document_type')
+        company_id = request.args.get('company_id', type=int)
+        start_str = request.args.get('start_date')
+        end_str = request.args.get('end_date')
+        limit = request.args.get('limit', 100, type=int)
+
         query = db.session.query(CvmDocument, Company.company_name).join(Company)
         if doc_type:
             query = query.filter(CvmDocument.document_type == doc_type)
+        if company_id:
+            query = query.filter(CvmDocument.company_id == company_id)
+        if start_str:
+            start_date = datetime.strptime(start_str, "%Y-%m-%d")
+            query = query.filter(CvmDocument.delivery_date >= start_date)
+        if end_str:
+            end_date = datetime.strptime(end_str, "%Y-%m-%d")
+            query = query.filter(CvmDocument.delivery_date <= end_date)
+
         docs = query.order_by(CvmDocument.delivery_date.desc()).limit(limit).all()
+
+        if not docs:
+            return jsonify({"success": True, "documents": []})
 
         documents = [
             {

--- a/test_documents_routes.py
+++ b/test_documents_routes.py
@@ -3,6 +3,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from backend import db
 from backend.models import Company, CvmDocument
 import backend.routes.documents_routes as documents_routes
+from datetime import datetime
 
 
 def test_get_documents_by_company(client):
@@ -23,6 +24,29 @@ def test_get_documents_by_company(client):
     assert data["documents"][0]["document_type"] == "DFP"
 
 
+def test_get_documents_by_company_filters(client):
+    with client.application.app_context():
+        company = Company(company_name="Filter Co", ticker="FLT")
+        db.session.add(company)
+        db.session.commit()
+        company_id = company.id
+        doc = CvmDocument(
+            company_id=company_id,
+            document_type="DFP",
+            delivery_date=datetime(2024, 1, 1),
+        )
+        db.session.add(doc)
+        db.session.commit()
+
+    resp = client.get(
+        f"/api/documents/by_company/{company_id}?document_type=ITR&start_date=2024-01-01"
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["success"] is True
+    assert data["documents"] == []
+
+
 def test_get_documents_by_company_handles_exception(client, monkeypatch):
     with client.application.app_context():
         company = Company(company_name="Test Co", ticker="TST")
@@ -40,3 +64,41 @@ def test_get_documents_by_company_handles_exception(client, monkeypatch):
     data = resp.get_json()
     assert data["success"] is False
     assert data["error"] == "Erro interno ao buscar documentos"
+
+
+def test_list_cvm_documents_filters(client):
+    with client.application.app_context():
+        comp_a = Company(company_name="CompA", ticker="A")
+        comp_b = Company(company_name="CompB", ticker="B")
+        db.session.add_all([comp_a, comp_b])
+        db.session.commit()
+        comp_a_id = comp_a.id
+        comp_b_id = comp_b.id
+        doc_a = CvmDocument(
+            company_id=comp_a_id,
+            document_type="DFP",
+            delivery_date=datetime(2024, 1, 1),
+        )
+        doc_b = CvmDocument(
+            company_id=comp_b_id,
+            document_type="ITR",
+            delivery_date=datetime(2024, 6, 1),
+        )
+        db.session.add_all([doc_a, doc_b])
+        db.session.commit()
+
+    resp = client.get(
+        f"/api/cvm/documents?company_id={comp_a_id}&document_type=DFP&start_date=2023-12-31&end_date=2024-12-31"
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["success"] is True
+    assert len(data["documents"]) == 1
+    assert data["documents"][0]["document_type"] == "DFP"
+
+    resp = client.get(
+        f"/api/cvm/documents?company_id={comp_a_id}&document_type=ITR"
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["documents"] == []


### PR DESCRIPTION
## Summary
- add optional document type and date filters to company document lookup
- expand CVM documents listing with company/date filters and error handling
- cover new filter logic with tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a0d7260208327886eb579a1f4a040