### PR TITLE
feat: add date range picker and debounce

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,8 @@ Resposta:
 }
 ```
 
+No dashboard, o filtro "Período de Publicação" dos Documentos CVM aceita datas no formato `YYYY-MM-DD`. Caso digite manualmente, é possível separar as datas com `-` ou `–` (por exemplo, `2024-01-01 - 2024-01-31`).
+
 ## Documentação Avançada
 
 Detalhes sobre a integração MetaTrader5 estão em [INTEGRACAO_METATRADER5.md](INTEGRACAO_METATRADER5.md).


### PR DESCRIPTION
## Summary
- switch CVM documents filter to start/end date fields
- debounce fetch to avoid repeated requests
- document accepted date format

## Testing
- `npm test` *(fails: TypeError: Cannot read properties of undefined (reading 'getIndicators'))*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a0d8d60008327b8c0249d25b99f93