### PR TITLE
Handle invalid date parameters for document search

### DIFF
--- a/backend/routes/documents_routes.py
+++ b/backend/routes/documents_routes.py
@@ -21,15 +21,30 @@ def get_documents_by_company_id(company_id):
         if not company:
             return jsonify({"success": False, "message": f"Empresa com ID {company_id} não encontrada"}), 404
 
-        query = db.session.query(CvmDocument).filter(CvmDocument.company_id == company_id)
+        query = db.session.query(CvmDocument).filter(
+            CvmDocument.company_id == company_id
+        )
         if doc_type:
             query = query.filter(CvmDocument.document_type == doc_type)
-        if start_str:
-            start_date = datetime.strptime(start_str, "%Y-%m-%d")
-            query = query.filter(CvmDocument.delivery_date >= start_date)
-        if end_str:
-            end_date = datetime.strptime(end_str, "%Y-%m-%d")
-            query = query.filter(CvmDocument.delivery_date <= end_date)
+
+        if start_str or end_str:
+            try:
+                if start_str:
+                    start_date = datetime.strptime(start_str, "%Y-%m-%d")
+                    query = query.filter(CvmDocument.delivery_date >= start_date)
+                if end_str:
+                    end_date = datetime.strptime(end_str, "%Y-%m-%d")
+                    query = query.filter(CvmDocument.delivery_date <= end_date)
+            except ValueError:
+                return (
+                    jsonify(
+                        {
+                            "success": False,
+                            "message": "Formato de data inválido. Use YYYY-MM-DD.",
+                        }
+                    ),
+                    400,
+                )
 
         docs = query.order_by(CvmDocument.delivery_date.desc()).limit(limit).all()
 

--- a/test_documents_routes.py
+++ b/test_documents_routes.py
@@ -48,6 +48,22 @@ def test_get_documents_by_company_filters(client):
     assert data["documents"] == []
 
 
+def test_get_documents_by_company_invalid_dates(client):
+    with client.application.app_context():
+        company = Company(company_name="Test Co", ticker="TST")
+        db.session.add(company)
+        db.session.commit()
+        company_id = company.id
+
+    resp = client.get(
+        f"/api/documents/by_company/{company_id}?start_date=2024-13-01"
+    )
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert data["success"] is False
+    assert "YYYY-MM-DD" in data["message"]
+
+
 def test_get_documents_by_company_handles_exception(client, monkeypatch):
     with client.application.app_context():
         company = Company(company_name="Test Co", ticker="TST")
@@ -108,7 +124,7 @@ def test_list_cvm_documents_filters(client):
     assert data["success"] is True
     assert len(data["documents"]) == 1
 
-    assert data["documents"][0]["company_name"] == "Test Co"
+    assert data["documents"][0]["company_name"] == "CompA"
     assert "company" not in data["documents"][0]
 
     assert data["documents"][0]["document_type"] == "DFP"


### PR DESCRIPTION
## Summary
- validate and safely parse optional date filters in `get_documents_by_company_id`
- return HTTP 400 with clear message when date format is invalid
- add regression test for malformed date parameters and fix existing expectations

## Testing
- `pytest test_documents_routes.py`


------
https://chatgpt.com/codex/tasks/task_e_689a3e94b2488327960c2201c9b6f62d