### PR TITLE
Handle invalid date parameters in CVM routes

### DIFF
--- a/backend/routes/documents_routes.py
+++ b/backend/routes/documents_routes.py
@@ -17,8 +17,23 @@ def get_documents_by_company_id(company_id):
         start_str = request.args.get('start_date')
         end_str = request.args.get('end_date')
 
-        start_date = datetime.strptime(start_str, "%Y-%m-%d") if start_str else None
-        end_date = datetime.strptime(end_str, "%Y-%m-%d") if end_str else None
+        start_date = end_date = None
+        if start_str or end_str:
+            try:
+                if start_str:
+                    start_date = datetime.strptime(start_str, "%Y-%m-%d")
+                if end_str:
+                    end_date = datetime.strptime(end_str, "%Y-%m-%d")
+            except ValueError:
+                return (
+                    jsonify(
+                        {
+                            "success": False,
+                            "message": "Formato de data inválido. Use YYYY-MM-DD.",
+                        }
+                    ),
+                    400,
+                )
 
         if start_date and end_date and start_date > end_date:
             return (
@@ -42,24 +57,10 @@ def get_documents_by_company_id(company_id):
             query = query.filter(CvmDocument.document_type == doc_type)
 
 
-        if start_str or end_str:
-            try:
-                if start_str:
-                    start_date = datetime.strptime(start_str, "%Y-%m-%d")
-                    query = query.filter(CvmDocument.delivery_date >= start_date)
-                if end_str:
-                    end_date = datetime.strptime(end_str, "%Y-%m-%d")
-                    query = query.filter(CvmDocument.delivery_date <= end_date)
-            except ValueError:
-                return (
-                    jsonify(
-                        {
-                            "success": False,
-                            "message": "Formato de data inválido. Use YYYY-MM-DD.",
-                        }
-                    ),
-                    400,
-                )
+        if start_date:
+            query = query.filter(CvmDocument.delivery_date >= start_date)
+        if end_date:
+            query = query.filter(CvmDocument.delivery_date <= end_date)
               
         docs = query.order_by(CvmDocument.delivery_date.desc()).limit(limit).all()
 
@@ -104,10 +105,32 @@ def list_cvm_documents():
         if company_id:
             query = query.filter(CvmDocument.company_id == company_id)
         if start_str:
-            start_date = datetime.strptime(start_str, "%Y-%m-%d")
+            try:
+                start_date = datetime.strptime(start_str, "%Y-%m-%d")
+            except ValueError:
+                return (
+                    jsonify(
+                        {
+                            "success": False,
+                            "message": "Formato de data inválido. Use YYYY-MM-DD.",
+                        }
+                    ),
+                    400,
+                )
             query = query.filter(CvmDocument.delivery_date >= start_date)
         if end_str:
-            end_date = datetime.strptime(end_str, "%Y-%m-%d")
+            try:
+                end_date = datetime.strptime(end_str, "%Y-%m-%d")
+            except ValueError:
+                return (
+                    jsonify(
+                        {
+                            "success": False,
+                            "message": "Formato de data inválido. Use YYYY-MM-DD.",
+                        }
+                    ),
+                    400,
+                )
             query = query.filter(CvmDocument.delivery_date <= end_date)
 
         docs = query.order_by(CvmDocument.delivery_date.desc()).limit(limit).all()

--- a/test_documents_routes.py
+++ b/test_documents_routes.py
@@ -140,3 +140,19 @@ def test_list_cvm_documents_filters(client):
     data = resp.get_json()
     assert data["documents"] == []
 
+
+def test_list_cvm_documents_invalid_date(client):
+    with client.application.app_context():
+        company = Company(company_name="Bad Date Co", ticker="BDC")
+        db.session.add(company)
+        db.session.commit()
+        doc = CvmDocument(company_id=company.id, document_type="DFP")
+        db.session.add(doc)
+        db.session.commit()
+
+    resp = client.get("/api/cvm/documents?start_date=2024-13-01")
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert data["success"] is False
+    assert "YYYY-MM-DD" in data["message"]
+


### PR DESCRIPTION
## Summary
- validate `start_date` and `end_date` parameters in CVM endpoints and return a 400 error for invalid formats
- add regression tests for invalid date on `/api/cvm/documents`

## Testing
- `pytest test_documents_routes.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689a416f01a083278b6b84584314e0a8