### PR TITLE
Add total count to documents route responses

### DIFF
--- a/backend/routes/documents_routes.py
+++ b/backend/routes/documents_routes.py
@@ -63,9 +63,10 @@ def get_documents_by_company_id(company_id):
             query = query.filter(CvmDocument.delivery_date <= end_date)
               
         docs = query.order_by(CvmDocument.delivery_date.desc()).limit(limit).all()
+        total = len(docs)
 
         if not docs:
-            return jsonify({"success": True, "documents": [], "total": 0})
+            return jsonify({"success": True, "documents": [], "total": total})
 
         doc_list = [{
             "id": doc.id,
@@ -83,6 +84,7 @@ def get_documents_by_company_id(company_id):
             "company_name": company.company_name,
             "ticker": company.ticker,
             "documents": doc_list,
+            "total": total,
         })
     except Exception as e:
         logger.exception(f"Erro em get_documents_by_company_id: {e}")

--- a/test_documents_routes.py
+++ b/test_documents_routes.py
@@ -21,6 +21,7 @@ def test_get_documents_by_company(client):
     data = resp.get_json()
     assert data["success"] is True
     assert len(data["documents"]) == 1
+    assert data["total"] == 1
     assert data["documents"][0]["document_type"] == "DFP"
     assert data["documents"][0]["company_name"] == "Test Co"
 
@@ -46,6 +47,7 @@ def test_get_documents_by_company_filters(client):
     data = resp.get_json()
     assert data["success"] is True
     assert data["documents"] == []
+    assert data["total"] == 0
 
 
 def test_get_documents_by_company_invalid_dates(client):


### PR DESCRIPTION
## Summary
- return total document count in `/api/documents/by_company/<id>` endpoint
- test the `total` field presence and values in document routes

## Testing
- `pytest test_documents_routes.py::test_get_documents_by_company test_documents_routes.py::test_get_documents_by_company_filters -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a42b1cf9c8327bfbfe841934c763c