### PR TITLE
Handle CVM filter fetch errors

### DIFF
--- a/frontend/components/CvmDocuments.tsx
+++ b/frontend/components/CvmDocuments.tsx
@@ -68,11 +68,21 @@ const CvmDocuments: React.FC = () => {
 
     useEffect(() => {
         const loadFilters = async () => {
-            const companyData: CvmCompany[] = await cvmService.getCompanies();
-            setCompanies([{ value: '', label: 'Todas' }, ...companyData.map(c => ({ value: String(c.id), label: `${c.ticker} - ${c.company_name}` }))]);
+            try {
+                const companyData: CvmCompany[] = await cvmService.getCompanies();
+                setCompanies([{ value: '', label: 'Todas' }, ...companyData.map(c => ({ value: String(c.id), label: `${c.ticker} - ${c.company_name}` }))]);
+            } catch (e: any) {
+                setCompanies([{ value: '', label: 'Todas' }]);
+                setError(e?.message || 'Erro ao carregar empresas');
+            }
 
-            const docTypes: CvmDocumentType[] = await cvmService.getDocumentTypes();
-            setDocumentTypes([{ value: '', label: 'Todas' }, ...docTypes.map(dt => ({ value: dt.code, label: dt.name }))]);
+            try {
+                const docTypes: CvmDocumentType[] = await cvmService.getDocumentTypes();
+                setDocumentTypes([{ value: '', label: 'Todas' }, ...docTypes.map(dt => ({ value: dt.code, label: dt.name }))]);
+            } catch (e: any) {
+                setDocumentTypes([{ value: '', label: 'Todas' }]);
+                setError(e?.message || 'Erro ao carregar tipos de documento');
+            }
         };
         loadFilters();
     }, []);


### PR DESCRIPTION
## Summary
- add error handling for CVM filter fetches

## Testing
- `npm test` *(fails: TypeError: Cannot read properties of undefined (reading 'getIndicators'))*

------
https://chatgpt.com/codex/tasks/task_e_689a3f59ecb483279dc5965615c19ccc