### PR TITLE
feat: add delivery date range filters

### DIFF
--- a/backend/routes/documents_routes.py
+++ b/backend/routes/documents_routes.py
@@ -57,9 +57,13 @@ def get_documents_by_company_id(company_id):
             query = query.filter(CvmDocument.document_type == doc_type)
 
 
-        if start_date:
+        if start_date and end_date:
+            query = query.filter(
+                CvmDocument.delivery_date.between(start_date, end_date)
+            )
+        elif start_date:
             query = query.filter(CvmDocument.delivery_date >= start_date)
-        if end_date:
+        elif end_date:
             query = query.filter(CvmDocument.delivery_date <= end_date)
               
         docs = query.order_by(CvmDocument.delivery_date.desc()).limit(limit).all()

--- a/test_documents_routes.py
+++ b/test_documents_routes.py
@@ -50,6 +50,116 @@ def test_get_documents_by_company_filters(client):
     assert data["total"] == 0
 
 
+def test_get_documents_by_company_start_date_only(client):
+    with client.application.app_context():
+        company = Company(company_name="Date Co", ticker="DCO")
+        db.session.add(company)
+        db.session.commit()
+        company_id = company.id
+        docs = [
+            CvmDocument(
+                company_id=company_id,
+                document_type="DFP",
+                delivery_date=datetime(2024, 1, 1),
+            ),
+            CvmDocument(
+                company_id=company_id,
+                document_type="DFP",
+                delivery_date=datetime(2024, 6, 1),
+            ),
+            CvmDocument(
+                company_id=company_id,
+                document_type="DFP",
+                delivery_date=datetime(2024, 12, 31),
+            ),
+        ]
+        db.session.add_all(docs)
+        db.session.commit()
+
+    resp = client.get(
+        f"/api/documents/by_company/{company_id}?start_date=2024-06-01"
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["success"] is True
+    assert len(data["documents"]) == 2
+    for doc in data["documents"]:
+        assert datetime.fromisoformat(doc["delivery_date"]) >= datetime(2024, 6, 1)
+
+
+def test_get_documents_by_company_end_date_only(client):
+    with client.application.app_context():
+        company = Company(company_name="Date Co", ticker="DCO")
+        db.session.add(company)
+        db.session.commit()
+        company_id = company.id
+        docs = [
+            CvmDocument(
+                company_id=company_id,
+                document_type="DFP",
+                delivery_date=datetime(2024, 1, 1),
+            ),
+            CvmDocument(
+                company_id=company_id,
+                document_type="DFP",
+                delivery_date=datetime(2024, 6, 1),
+            ),
+            CvmDocument(
+                company_id=company_id,
+                document_type="DFP",
+                delivery_date=datetime(2024, 12, 31),
+            ),
+        ]
+        db.session.add_all(docs)
+        db.session.commit()
+
+    resp = client.get(
+        f"/api/documents/by_company/{company_id}?end_date=2024-06-01"
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["success"] is True
+    assert len(data["documents"]) == 2
+    for doc in data["documents"]:
+        assert datetime.fromisoformat(doc["delivery_date"]) <= datetime(2024, 6, 1)
+
+
+def test_get_documents_by_company_between_dates(client):
+    with client.application.app_context():
+        company = Company(company_name="Date Co", ticker="DCO")
+        db.session.add(company)
+        db.session.commit()
+        company_id = company.id
+        docs = [
+            CvmDocument(
+                company_id=company_id,
+                document_type="DFP",
+                delivery_date=datetime(2024, 1, 1),
+            ),
+            CvmDocument(
+                company_id=company_id,
+                document_type="DFP",
+                delivery_date=datetime(2024, 6, 1),
+            ),
+            CvmDocument(
+                company_id=company_id,
+                document_type="DFP",
+                delivery_date=datetime(2024, 12, 31),
+            ),
+        ]
+        db.session.add_all(docs)
+        db.session.commit()
+
+    resp = client.get(
+        f"/api/documents/by_company/{company_id}?start_date=2024-02-01&end_date=2024-11-01"
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["success"] is True
+    assert len(data["documents"]) == 1
+    assert datetime.fromisoformat(data["documents"][0]["delivery_date"]) == datetime(2024, 6, 1)
+
+
 def test_get_documents_by_company_invalid_dates(client):
     with client.application.app_context():
         company = Company(company_name="Test Co", ticker="TST")


### PR DESCRIPTION
## Summary
- ensure document queries respect combined start/end date filters
- cover document filtering by start, end, and range in tests

## Testing
- `pytest test_documents_routes.py`


------
https://chatgpt.com/codex/tasks/task_e_689a45b9ee388327b7032c6e8af94a71