### PR TITLE
Allow tickers without company

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -105,10 +105,11 @@ class Ticker(db.Model):
     __tablename__ = 'tickers'
     id = db.Column(Integer, primary_key=True)
     symbol = db.Column(String(20), unique=True, nullable=False, index=True)
-    company_id = db.Column(Integer, ForeignKey('companies.id'), nullable=False, index=True)
-    
-    # ADICIONADO: A coluna 'type' que existe na sua tabela
-    type = db.Column(String(50)) 
+    # company_id agora é opcional para permitir ativos sem empresa vinculada
+    company_id = db.Column(Integer, ForeignKey('companies.id'), nullable=True, index=True)
+
+    # Mantido para diferenciar tipos de ativos (ex.: stock, etf, future)
+    type = db.Column(String(50))
     
     # REMOVIDO: A coluna 'is_active' que não existe na sua tabela
     # is_active = db.Column(Boolean, default=True)
@@ -223,6 +224,7 @@ class PortfolioPosition(db.Model):
 
     portfolio = relationship("Portfolio", back_populates="positions")
     ticker = relationship("Ticker", foreign_keys=[symbol], primaryjoin="PortfolioPosition.symbol == Ticker.symbol")
+    # Relaciona pelo símbolo para também abranger ativos sem company_id
     metrics = relationship(
         "AssetMetrics",
         foreign_keys=[symbol],

--- a/migrations/versions/5a6c7d8e9f10_make_ticker_company_id_nullable.py
+++ b/migrations/versions/5a6c7d8e9f10_make_ticker_company_id_nullable.py
@@ -1,0 +1,23 @@
+"""make ticker company_id nullable
+
+Revision ID: 5a6c7d8e9f10
+Revises: 0f54de82af65
+Create Date: 2025-08-12 15:37:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = '5a6c7d8e9f10'
+down_revision: Union[str, Sequence[str], None] = '0f54de82af65'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.alter_column('tickers', 'company_id', existing_type=sa.Integer(), nullable=True)
+
+
+def downgrade() -> None:
+    op.alter_column('tickers', 'company_id', existing_type=sa.Integer(), nullable=False)


### PR DESCRIPTION
## Summary
- allow tickers to omit `company_id` and document type usage
- note PortfolioPosition uses symbol to fetch metrics
- migration: make tickers.company_id nullable

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b5e66d5a883279d6c5bd86b56ef72