### PR TITLE
Use outer join for ticker search

### DIFF
--- a/backend/routes/tickers_routes.py
+++ b/backend/routes/tickers_routes.py
@@ -8,6 +8,7 @@ import logging
 logger = logging.getLogger(__name__)
 tickers_bp = Blueprint('tickers_bp', __name__)
 
+
 @tickers_bp.route('/search', methods=['GET'])
 def search_tickers():
     query = request.args.get('q', '').strip()
@@ -16,21 +17,36 @@ def search_tickers():
 
     try:
         search_term = f"%{query.upper()}%"
-        
-        results = db.session.query(Ticker).join(Company).filter(
-            or_(
-                Ticker.symbol.ilike(search_term),
-                # CORREÇÃO: Usando Company.company_name na busca
-                Company.company_name.ilike(search_term) 
+
+        results = (
+            db.session.query(Ticker)
+            .outerjoin(Company)
+            .filter(
+                or_(
+                    Ticker.symbol.ilike(search_term),
+                    # CORREÇÃO: Usando Company.company_name na busca
+                    Company.company_name.ilike(search_term),
+                    # Permite que company_name seja nulo
+                    Company.company_name.is_(None),
+                )
             )
-        ).limit(15).all()
+            .limit(15)
+            .all()
+        )
 
         # --- CORREÇÃO PRINCIPAL AQUI ---
         # A resposta agora usa t.company.company_name, que é o nome correto do atributo.
-        tickers_data = [{'symbol': t.symbol, 'company_name': t.company.company_name} for t in results]
-        
+        tickers_data = [
+            {
+                'symbol': t.symbol,
+                'company_name': t.company.company_name if t.company else None,
+            }
+            for t in results
+        ]
+
         return jsonify({"success": True, "query": query, "results": tickers_data, "count": len(tickers_data)})
 
     except Exception as e:
         logger.error(f"Erro detalhado em search_tickers: {e}")
         return jsonify({"error": "Erro interno ao buscar tickers.", "details": str(e)}), 500
+


### PR DESCRIPTION
## Summary
- allow ticker search to return results even when the related company is missing by switching to `outerjoin`
- include company name in response only when available

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b60b4ec808327af94020d4e227647