### PR TITLE
chore(frontend): expose dev server host

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -8,6 +8,9 @@ export default defineConfig(() => {
           '@': path.resolve(__dirname, '.'),
         }
       },
+      server: {
+        host: true,
+      },
       test: {
         globals: true,
         environment: 'jsdom',


### PR DESCRIPTION
## Summary
- allow Vite dev server to listen on all interfaces

## Testing
- `npm test` *(fails: Cannot read properties of undefined (reading 'getIndicators'))*


------
https://chatgpt.com/codex/tasks/task_e_689b600b1c58832785062e2493da56b6