### PR TITLE
feat: allow order parameter for latest news

### DIFF
--- a/backend/routes/news_routes.py
+++ b/backend/routes/news_routes.py
@@ -21,15 +21,21 @@ def get_news_by_ticker(ticker):
 def get_latest_news():
     limit = request.args.get('limit', 10, type=int)
     portal = request.args.get('portal')
+    order = request.args.get('order', 'desc').lower()
+
+    if order not in ('asc', 'desc'):
+        return jsonify({'error': "Parâmetro 'order' inválido"}), 400
+
     query = MarketArticle.query
     if portal:
         query = query.filter(MarketArticle.portal == portal)
-    articles = (
-        query
-        .order_by(MarketArticle.data_publicacao.desc())
-        .limit(limit)
-        .all()
+
+    order_clause = (
+        MarketArticle.data_publicacao.asc()
+        if order == 'asc'
+        else MarketArticle.data_publicacao.desc()
     )
+    articles = query.order_by(order_clause).limit(limit).all()
     return jsonify([a.to_dict() for a in articles])
 
 


### PR DESCRIPTION
## Summary
- add `order` query parameter to `/api/news/latest` to sort by publication date
- validate `order` accepts `asc` or `desc`
- test ordering behavior and invalid parameter

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b63712f04832794f1e7f15b172a77