### PR TITLE
feat: add order parameter to news service

### DIFF
--- a/frontend/components/MarketNews.tsx
+++ b/frontend/components/MarketNews.tsx
@@ -30,7 +30,7 @@ const MarketNews: React.FC = () => {
     useEffect(() => {
         (async () => {
             try {
-                const data = await newsService.getLatestNews(limit);
+                const data = await newsService.getLatestNews(limit, undefined, 'desc');
                 setNewsArticles(data);
                 if (!selectedArticle && data.length > 0) {
                     await handleSelectArticle(data[0]);

--- a/frontend/services/newsService.ts
+++ b/frontend/services/newsService.ts
@@ -23,12 +23,14 @@ export const getCompanyNews = async (
 
 export const getLatestNews = async (
   limit = 10,
-  portal?: string
+  portal?: string,
+  order: 'asc' | 'desc' = 'desc'
 ): Promise<MarketNewsArticle[]> => {
   const params = new URLSearchParams({ limit: String(limit) });
   if (portal) {
     params.append('portal', portal);
   }
+  params.append('order', order);
   const res = await fetch(`${API_BASE}/news/latest?${params.toString()}`);
   if (!res.ok) {
     throw new Error('Falha ao buscar últimas notícias');


### PR DESCRIPTION
## Summary
- allow ordering of latest news via `order` parameter in newsService
- update MarketNews component to request news in descending order

## Testing
- `npm test` *(fails: Cannot read properties of undefined (reading 'getIndicators') in macroService tests)*

------
https://chatgpt.com/codex/tasks/task_e_689b63733bdc832795396849feb13d15