### PR TITLE
feat(frontend): add news ordering option

### DIFF
--- a/frontend/components/MarketNews.tsx
+++ b/frontend/components/MarketNews.tsx
@@ -8,6 +8,7 @@ const MarketNews: React.FC = () => {
     const [newsArticles, setNewsArticles] = useState<MarketNewsArticle[]>([]);
     const [selectedArticle, setSelectedArticle] = useState<MarketNewsArticle | null>(null);
     const [portalFilter, setPortalFilter] = useState('');
+    const [order, setOrder] = useState<'asc' | 'desc'>('desc');
 
     const portals = useMemo(() => Array.from(new Set(newsArticles.map(n => n.source))), [newsArticles]);
 
@@ -30,7 +31,7 @@ const MarketNews: React.FC = () => {
     useEffect(() => {
         (async () => {
             try {
-                const data = await newsService.getLatestNews(limit);
+                const data = await newsService.getLatestNews(limit, portalFilter || undefined, order);
                 setNewsArticles(data);
                 if (!selectedArticle && data.length > 0) {
                     await handleSelectArticle(data[0]);
@@ -39,7 +40,7 @@ const MarketNews: React.FC = () => {
                 console.error('Erro ao carregar notícias', err);
             }
         })();
-    }, [limit]);
+    }, [limit, order]);
 
     return (
         <div className="flex h-full gap-4 text-slate-300">
@@ -55,16 +56,26 @@ const MarketNews: React.FC = () => {
                             <CurrencyDollarIcon /> Cripto
                         </button>
                     </div>
-                    <select
-                        value={portalFilter}
-                        onChange={(e) => setPortalFilter(e.target.value)}
-                        className="bg-slate-800 text-slate-300 text-sm rounded-md border border-slate-700 px-2 py-1"
-                    >
-                        <option value="">Todos</option>
-                        {portals.map(portal => (
-                            <option key={portal} value={portal}>{portal.toUpperCase()}</option>
-                        ))}
-                    </select>
+                    <div className="flex items-center gap-2">
+                        <select
+                            value={portalFilter}
+                            onChange={(e) => setPortalFilter(e.target.value)}
+                            className="bg-slate-800 text-slate-300 text-sm rounded-md border border-slate-700 px-2 py-1"
+                        >
+                            <option value="">Todos</option>
+                            {portals.map(portal => (
+                                <option key={portal} value={portal}>{portal.toUpperCase()}</option>
+                            ))}
+                        </select>
+                        <select
+                            value={order}
+                            onChange={(e) => setOrder(e.target.value as 'asc' | 'desc')}
+                            className="bg-slate-800 text-slate-300 text-sm rounded-md border border-slate-700 px-2 py-1"
+                        >
+                            <option value="desc">Mais recentes</option>
+                            <option value="asc">Mais antigas</option>
+                        </select>
+                    </div>
                 </div>
                 <div className="flex-grow overflow-y-auto pr-1">
                     {newsArticles
@@ -81,7 +92,7 @@ const MarketNews: React.FC = () => {
                             <p className="text-xs text-slate-400 mt-1">{news.summary}</p>
                             <div className="flex items-center justify-between mt-1.5">
                                 <span className="text-xs text-slate-400">{news.source.toUpperCase()}</span>
-                                <span className="text-xs text-slate-500">{news.timestamp}</span>
+                                <span className="text-xs text-slate-500">{new Date(news.timestamp).toLocaleDateString()}</span>
                             </div>
                         </div>
                     ))}
@@ -104,7 +115,7 @@ const MarketNews: React.FC = () => {
                         <div className="flex justify-between items-start mb-4">
                             <div>
                                 <h1 className="text-2xl font-bold text-white">{selectedArticle.title}</h1>
-                                <p className="text-sm text-slate-400 mt-1">{selectedArticle.timestamp} • {selectedArticle.source}</p>
+                                <p className="text-sm text-slate-400 mt-1">{new Date(selectedArticle.timestamp).toLocaleDateString()} • {selectedArticle.source}</p>
                             </div>
                             <button onClick={() => setSelectedArticle(newsArticles[0] || null)} className="p-1 text-slate-400 hover:text-white rounded-full hover:bg-slate-700">
                                 <XMarkIcon className="w-5 h-5"/>

--- a/frontend/services/newsService.ts
+++ b/frontend/services/newsService.ts
@@ -23,9 +23,10 @@ export const getCompanyNews = async (
 
 export const getLatestNews = async (
   limit = 10,
-  portal?: string
+  portal?: string,
+  order: 'asc' | 'desc' = 'desc'
 ): Promise<MarketNewsArticle[]> => {
-  const params = new URLSearchParams({ limit: String(limit) });
+  const params = new URLSearchParams({ limit: String(limit), order });
   if (portal) {
     params.append('portal', portal);
   }


### PR DESCRIPTION
## Summary
- allow ordering news from newest or oldest
- pass sorting order to news service and show formatted dates

## Testing
- `npm test` *(fails: TypeError: Cannot read properties of undefined (reading 'getIndicators'))*

------
https://chatgpt.com/codex/tasks/task_e_689b6378d9248327b607de32f8954248