### PR TITLE
test: add order tests for latest news endpoint

### DIFF
--- a/backend/routes/news_routes.py
+++ b/backend/routes/news_routes.py
@@ -21,15 +21,17 @@ def get_news_by_ticker(ticker):
 def get_latest_news():
     limit = request.args.get('limit', 10, type=int)
     portal = request.args.get('portal')
+    order = request.args.get('order', 'desc')
     query = MarketArticle.query
     if portal:
         query = query.filter(MarketArticle.portal == portal)
-    articles = (
-        query
-        .order_by(MarketArticle.data_publicacao.desc())
-        .limit(limit)
-        .all()
-    )
+
+    if order == 'asc':
+        query = query.order_by(MarketArticle.data_publicacao.asc())
+    else:
+        query = query.order_by(MarketArticle.data_publicacao.desc())
+
+    articles = query.limit(limit).all()
     return jsonify([a.to_dict() for a in articles])
 
 

--- a/test_news_routes.py
+++ b/test_news_routes.py
@@ -1,4 +1,6 @@
 import pytest
+from datetime import datetime
+from email.utils import parsedate_to_datetime
 from backend import db
 from backend.models import MarketArticle
 
@@ -41,3 +43,31 @@ def test_get_latest_news_portal_filter(client):
     data = resp.get_json()
     assert len(data) == 1
     assert data[0]['portal'] == 'PortalA'
+
+
+def test_get_latest_news_order_asc(client):
+    with client.application.app_context():
+        db.session.add(MarketArticle(titulo='Old', data_publicacao=datetime(2024, 1, 1), tickers_relacionados=[]))
+        db.session.add(MarketArticle(titulo='Mid', data_publicacao=datetime(2024, 1, 2), tickers_relacionados=[]))
+        db.session.add(MarketArticle(titulo='New', data_publicacao=datetime(2024, 1, 3), tickers_relacionados=[]))
+        db.session.commit()
+
+    resp = client.get('/api/news/latest?order=asc')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    dates = [parsedate_to_datetime(item['data_publicacao']) for item in data]
+    assert dates == sorted(dates)
+
+
+def test_get_latest_news_order_desc(client):
+    with client.application.app_context():
+        db.session.add(MarketArticle(titulo='Old', data_publicacao=datetime(2024, 1, 1), tickers_relacionados=[]))
+        db.session.add(MarketArticle(titulo='Mid', data_publicacao=datetime(2024, 1, 2), tickers_relacionados=[]))
+        db.session.add(MarketArticle(titulo='New', data_publicacao=datetime(2024, 1, 3), tickers_relacionados=[]))
+        db.session.commit()
+
+    resp = client.get('/api/news/latest?order=desc')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    dates = [parsedate_to_datetime(item['data_publicacao']) for item in data]
+    assert dates == sorted(dates, reverse=True)


### PR DESCRIPTION
## Summary
- allow sorting by publication date on `/api/news/latest`
- add tests ensuring ascending and descending ordering

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b637ec1748327a0f9e944c549c919