### PR TITLE
Enhance portfolio summary with detailed holding metrics

### DIFF
--- a/frontend/components/PortfolioDashboard.tsx
+++ b/frontend/components/PortfolioDashboard.tsx
@@ -22,6 +22,8 @@ const PortfolioDashboard: React.FC = () => {
   }, []);
 
   const holdings = portfolio?.holdings ?? [];
+  const formatCurrency = (v: number) => `R$ ${v.toFixed(2)}`;
+  const formatPercent = (v: number) => `${v.toFixed(2)}%`;
 
   return (
     <div className="space-y-6">
@@ -55,11 +57,11 @@ const PortfolioDashboard: React.FC = () => {
                     <tr key={h.symbol} className="border-b border-slate-700 hover:bg-slate-700/30">
                       <td className="px-4 py-3 font-medium text-white whitespace-nowrap">{h.symbol}</td>
                       <td className="px-4 py-3">{h.quantity}</td>
-                      <td className="px-4 py-3">R$ {h.avg_price.toFixed(2)}</td>
-                      <td className="px-4 py-3">R$ {h.current_price.toFixed(2)}</td>
-                      <td className="px-4 py-3">R$ {h.value.toFixed(2)}</td>
-                      <td className={`px-4 py-3 ${h.gain >= 0 ? 'text-green-400' : 'text-red-400'}`}>R$ {h.gain.toFixed(2)}</td>
-                      <td className={`px-4 py-3 ${h.gain >= 0 ? 'text-green-400' : 'text-red-400'}`}>{h.gain_percent.toFixed(2)}%</td>
+                      <td className="px-4 py-3">{formatCurrency(h.avg_price)}</td>
+                      <td className="px-4 py-3">{formatCurrency(h.last_price)}</td>
+                      <td className="px-4 py-3">{formatCurrency(h.position_value)}</td>
+                      <td className={`px-4 py-3 ${h.gain >= 0 ? 'text-green-400' : 'text-red-400'}`}>{formatCurrency(h.gain)}</td>
+                      <td className={`px-4 py-3 ${h.gain >= 0 ? 'text-green-400' : 'text-red-400'}`}>{formatPercent(h.gain_percent)}</td>
                     </tr>
                   ))}
                 </tbody>

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -19,16 +19,20 @@ export type Page =
   | 'sell-side';
 
 export interface Asset {
-  ticker: string;
-  price: number;
-  dailyChange: number;
-  contribution: number;
+  symbol: string;
   quantity: number;
-  positionValue: number;
-  positionPercent: number;
-  targetPercent: number;
+  avg_price: number;
+  last_price: number;
+  daily_change_pct: number;
+  contribution: number;
+  position_value: number;
+  position_pct: number;
+  target_pct: number;
   difference: number;
-  adjustment: number;
+  adjustment_qty: number;
+  cost: number;
+  gain: number;
+  gain_percent: number;
 }
 
 export interface PortfolioSummary {
@@ -38,7 +42,7 @@ export interface PortfolioSummary {
   total_cost: number;
   total_gain: number;
   total_gain_percent: number;
-  holdings: PortfolioHolding[];
+  holdings: Asset[];
 }
 
 export interface PortfolioDailyValue {
@@ -47,17 +51,6 @@ export interface PortfolioDailyValue {
   total_cost: number;
   total_gain: number;
   total_gain_percent: number;
-}
-
-export interface PortfolioHolding {
-  symbol: string;
-  quantity: number;
-  avg_price: number;
-  current_price: number;
-  value: number;
-  cost: number;
-  gain: number;
-  gain_percent: number;
 }
 
 export interface ChatMessage {


### PR DESCRIPTION
## Summary
- extend backend portfolio summary to compute detailed holding metrics including prices, position weights and rebalance guidance
- expose enriched asset structure to the frontend and use it in the portfolio dashboard
- format currency and percentage values consistently in the holdings table

## Testing
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b68688fa08327af4f9ca8bc8434f8