### PR TITLE
feat: track article collection timestamp

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -186,6 +186,7 @@ class MarketArticle(db.Model):
     conteudo_completo = db.Column(Text)
     autor = db.Column(String(255))
     data_publicacao = db.Column(DateTime)
+    data_coleta = db.Column(DateTime)
     categoria = db.Column(String(255))
     tickers_relacionados = db.Column(JSON)
     score_impacto = db.Column(Numeric(10, 4))

--- a/backend/routes/news_routes.py
+++ b/backend/routes/news_routes.py
@@ -11,7 +11,7 @@ def get_news_by_ticker(ticker):
     articles = (
         MarketArticle.query
         .filter(MarketArticle.tickers_relacionados.contains([ticker_upper]))
-        .order_by(MarketArticle.data_publicacao.desc())
+        .order_by(MarketArticle.data_coleta.desc())
         .all()
     )
     return jsonify([a.to_dict() for a in articles])
@@ -31,9 +31,9 @@ def get_latest_news():
         query = query.filter(MarketArticle.portal == portal)
 
     order_clause = (
-        MarketArticle.data_publicacao.asc()
+        MarketArticle.data_coleta.asc()
         if order == 'asc'
-        else MarketArticle.data_publicacao.desc()
+        else MarketArticle.data_coleta.desc()
     )
     articles = query.order_by(order_clause).limit(limit).all()
     return jsonify([a.to_dict() for a in articles])

--- a/frontend/components/MarketNews.tsx
+++ b/frontend/components/MarketNews.tsx
@@ -94,7 +94,7 @@ const MarketNews: React.FC = () => {
                             <p className="text-xs text-slate-400 mt-1">{news.summary}</p>
                             <div className="flex items-center justify-between mt-1.5">
                                 <span className="text-xs text-slate-400">{news.source.toUpperCase()}</span>
-                                <span className="text-xs text-slate-500">{new Date(news.timestamp).toLocaleDateString()}</span>
+                                <span className="text-xs text-slate-500">{new Date(news.collectedAt).toLocaleDateString()}</span>
                             </div>
                         </div>
                     ))}
@@ -117,7 +117,7 @@ const MarketNews: React.FC = () => {
                         <div className="flex justify-between items-start mb-4">
                             <div>
                                 <h1 className="text-2xl font-bold text-white">{selectedArticle.title}</h1>
-                                <p className="text-sm text-slate-400 mt-1">{new Date(selectedArticle.timestamp).toLocaleDateString()} • {selectedArticle.source}</p>
+                                <p className="text-sm text-slate-400 mt-1">{new Date(selectedArticle.collectedAt).toLocaleDateString()} • {selectedArticle.source}</p>
                             </div>
                             <button onClick={() => setSelectedArticle(newsArticles[0] || null)} className="p-1 text-slate-400 hover:text-white rounded-full hover:bg-slate-700">
                                 <XMarkIcon className="w-5 h-5"/>

--- a/frontend/services/newsService.ts
+++ b/frontend/services/newsService.ts
@@ -16,7 +16,7 @@ export const getCompanyNews = async (
     title: item.titulo,
     summary: item.resumo,
     source: item.portal,
-    publishedDate: item.data_publicacao,
+    publishedDate: item.data_coleta,
     url: item.link_url || item.url,
   }));
 };
@@ -41,7 +41,7 @@ export const getLatestNews = async (
     id: Number(item.id ?? idx),
     title: item.titulo,
     source: item.portal,
-    timestamp: item.data_publicacao,
+    collectedAt: item.data_coleta,
     summary: item.resumo,
     content:
       item.conteudo_completo ||

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -91,7 +91,7 @@ export interface MarketNewsArticle {
     id: number;
     title: string;
     source: string;
-    timestamp: string;
+    collectedAt: string;
     summary: string;
     content: string;
     url: string;

--- a/migrations/versions/3bba235f3ec0_add_data_coleta_to_marketarticle.py
+++ b/migrations/versions/3bba235f3ec0_add_data_coleta_to_marketarticle.py
@@ -1,0 +1,28 @@
+"""add data_coleta to MarketArticle
+
+Revision ID: 3bba235f3ec0
+Revises: 5a6c7d8e9f10
+Create Date: 2025-08-12 17:09:26.806461
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '3bba235f3ec0'
+down_revision: Union[str, Sequence[str], None] = '5a6c7d8e9f10'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column('artigos_mercado', sa.Column('data_coleta', sa.DateTime(), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column('artigos_mercado', 'data_coleta')

--- a/test_news_routes.py
+++ b/test_news_routes.py
@@ -48,12 +48,12 @@ def test_get_latest_news_ordering(client):
     with client.application.app_context():
         older = MarketArticle(
             titulo='Old',
-            data_publicacao=datetime(2024, 1, 1),
+            data_coleta=datetime(2024, 1, 1),
             tickers_relacionados=[],
         )
         newer = MarketArticle(
             titulo='New',
-            data_publicacao=datetime(2024, 1, 2),
+            data_coleta=datetime(2024, 1, 2),
             tickers_relacionados=[],
         )
         db.session.add_all([older, newer])


### PR DESCRIPTION
## Summary
- add `data_coleta` to MarketArticle model and migration
- order news queries by collection time and expose to frontend
- rename MarketNewsArticle timestamp to `collectedAt`

## Testing
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b745d86748327920131d0fb1f4cd9