### PR TITLE
feat: add portfolio charts and ibov data

### DIFF
--- a/backend/routes/portfolio_routes.py
+++ b/backend/routes/portfolio_routes.py
@@ -343,3 +343,27 @@ def get_portfolio_daily_values(portfolio_id: int):
             jsonify({"success": False, "error": "Erro ao buscar histórico"}),
             500,
         )
+
+
+@portfolio_bp.route("/<int:portfolio_id>/daily-contribution", methods=["GET"])
+def get_portfolio_daily_contribution(portfolio_id: int):
+    """Retorna a contribuição diária por ativo do portfólio."""
+    try:
+        summary = calculate_portfolio_summary(portfolio_id)
+        if not summary:
+            return (
+                jsonify({"success": False, "error": "Portfólio não encontrado"}),
+                404,
+            )
+
+        contributions = [
+            {"symbol": h["symbol"], "contribution": h["contribution"]}
+            for h in summary["holdings"]
+        ]
+        return jsonify({"success": True, "contributions": contributions})
+    except Exception as e:
+        logger.error(f"Erro ao calcular contribuição diária: {e}")
+        return (
+            jsonify({"success": False, "error": "Erro ao calcular contribuição diária"}),
+            500,
+        )

--- a/frontend/components/PortfolioCharts.tsx
+++ b/frontend/components/PortfolioCharts.tsx
@@ -1,0 +1,89 @@
+import React, { useEffect, useState, useMemo } from 'react';
+import { BarChart, Bar, XAxis, YAxis, Tooltip, Legend, ResponsiveContainer, CartesianGrid, LineChart, Line } from 'recharts';
+import { portfolioApi } from '../services/portfolioApi';
+import { AssetContribution, PortfolioDailyValue, IbovHistoryPoint } from '../types';
+
+const COLORS = ['#8884d8', '#82ca9d', '#ffc658', '#ff8042', '#8dd1e1', '#a4de6c', '#d0ed57'];
+
+const PortfolioCharts: React.FC = () => {
+  const [contrib, setContrib] = useState<AssetContribution[]>([]);
+  const [dailyValues, setDailyValues] = useState<PortfolioDailyValue[]>([]);
+  const [ibov, setIbov] = useState<IbovHistoryPoint[]>([]);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const [c, pv, ib] = await Promise.all([
+          portfolioApi.getDailyContribution(1),
+          portfolioApi.getPortfolioDailyValues(1),
+          portfolioApi.getIbovHistory(),
+        ]);
+        setContrib(c);
+        setDailyValues(pv);
+        setIbov(ib);
+      } catch (err) {
+        console.error('Erro ao carregar gráficos do portfólio', err);
+      }
+    };
+    load();
+  }, []);
+
+  const contributionData = useMemo(() => {
+    const base: Record<string, number | string> = { name: 'Hoje' };
+    contrib.forEach((c) => {
+      base[c.symbol] = c.contribution;
+    });
+    return [base];
+  }, [contrib]);
+
+  const lineData = useMemo(() => {
+    if (!dailyValues.length || !ibov.length) return [];
+    const startPortfolio = dailyValues[0].total_value;
+    const ibovStart = ibov[0].close;
+    const ibovMap = Object.fromEntries(ibov.map(i => [i.date, i.close]));
+    return dailyValues.map(v => {
+      const ibClose = ibovMap[v.date];
+      return {
+        date: v.date,
+        portfolio: ((v.total_value / startPortfolio) - 1) * 100,
+        ibov: ibClose ? ((ibClose / ibovStart) - 1) * 100 : null,
+      };
+    });
+  }, [dailyValues, ibov]);
+
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      <div className="bg-slate-800/50 rounded-lg p-6 border border-slate-700">
+        <h2 className="text-xl font-semibold text-white mb-4">Contribuição para Variação Diária</h2>
+        <ResponsiveContainer width="100%" height={300}>
+          <BarChart data={contributionData}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="name" />
+            <YAxis />
+            <Tooltip />
+            <Legend />
+            {contrib.map((c, idx) => (
+              <Bar key={c.symbol} dataKey={c.symbol} stackId="a" fill={COLORS[idx % COLORS.length]} />
+            ))}
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+      <div className="bg-slate-800/50 rounded-lg p-6 border border-slate-700">
+        <h2 className="text-xl font-semibold text-white mb-4">Retorno Acumulado: Cota vs. Ibovespa</h2>
+        <ResponsiveContainer width="100%" height={300}>
+          <LineChart data={lineData}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="date" />
+            <YAxis tickFormatter={(v) => `${v.toFixed(2)}%`} />
+            <Tooltip formatter={(v: number) => `${v.toFixed(2)}%`} />
+            <Legend />
+            <Line type="monotone" dataKey="portfolio" stroke="#8884d8" dot={false} />
+            <Line type="monotone" dataKey="ibov" stroke="#82ca9d" dot={false} />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+};
+
+export default PortfolioCharts;

--- a/frontend/components/PortfolioDashboard.tsx
+++ b/frontend/components/PortfolioDashboard.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import PortfolioManager from './PortfolioManager';
+import PortfolioCharts from './PortfolioCharts';
 import { PortfolioSummary } from '../types';
 import { portfolioApi } from '../services/portfolioApi';
 
@@ -40,68 +41,71 @@ const PortfolioDashboard: React.FC = () => {
       {error && <p className="text-red-400">{error}</p>}
 
       {portfolio && (
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-          <div className="lg:col-span-2 bg-slate-800/50 rounded-lg p-6 border border-slate-700">
-            <h2 className="text-xl font-semibold text-white mb-4">Composição da Carteira</h2>
-            <div className="overflow-x-auto">
-              <table className="w-full text-sm text-left text-slate-300">
-                <thead className="text-xs text-slate-400 uppercase bg-slate-700/50">
-                  <tr>
-                    {['Ativo','Qtd','Preço Médio','Preço Atual','Valor','P/L','P/L%'].map(h => (
-                      <th key={h} className="px-4 py-3 whitespace-nowrap">{h}</th>
-                    ))}
-                  </tr>
-                </thead>
-                <tbody>
-                  {holdings.map(h => (
-                    <tr key={h.symbol} className="border-b border-slate-700 hover:bg-slate-700/30">
-                      <td className="px-4 py-3 font-medium text-white whitespace-nowrap">{h.symbol}</td>
-                      <td className="px-4 py-3">{h.quantity}</td>
-                      <td className="px-4 py-3">{formatCurrency(h.avg_price)}</td>
-                      <td className="px-4 py-3">{formatCurrency(h.last_price)}</td>
-                      <td className="px-4 py-3">{formatCurrency(h.position_value)}</td>
-                      <td className={`px-4 py-3 ${h.gain >= 0 ? 'text-green-400' : 'text-red-400'}`}>{formatCurrency(h.gain)}</td>
-                      <td className={`px-4 py-3 ${h.gain >= 0 ? 'text-green-400' : 'text-red-400'}`}>{formatPercent(h.gain_percent)}</td>
+        <>
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+            <div className="lg:col-span-2 bg-slate-800/50 rounded-lg p-6 border border-slate-700">
+              <h2 className="text-xl font-semibold text-white mb-4">Composição da Carteira</h2>
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm text-left text-slate-300">
+                  <thead className="text-xs text-slate-400 uppercase bg-slate-700/50">
+                    <tr>
+                      {['Ativo','Qtd','Preço Médio','Preço Atual','Valor','P/L','P/L%'].map(h => (
+                        <th key={h} className="px-4 py-3 whitespace-nowrap">{h}</th>
+                      ))}
                     </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          </div>
-          <div className="bg-slate-800/50 rounded-lg p-6 border border-slate-700 h-fit">
-            <h2 className="text-xl font-semibold text-white mb-4">Resumo do Portfólio</h2>
-            <div className="space-y-2 text-sm">
-              <div className="flex justify-between">
-                <span className="text-slate-400">Patrimônio Líquido:</span>
-                <span className="font-medium text-white">{formatCurrency(portfolio.patrimonio_liquido)}</span>
-              </div>
-              <div className="flex justify-between">
-                <span className="text-slate-400">Valor da Cota:</span>
-                <span className="font-medium text-white">R$ {portfolio.valor_cota.toFixed(2)}</span>
-              </div>
-              <div className={`flex justify-between ${portfolio.variacao_cota_pct >= 0 ? 'text-green-400' : 'text-red-400'}`}>
-                <span>Variação da Cota:</span>
-                <span>{formatPercent(portfolio.variacao_cota_pct)}</span>
-              </div>
-              <div className="flex justify-between">
-                <span className="text-slate-400">Posição Comprada:</span>
-                <span className="font-medium text-white">{formatPercent(portfolio.posicao_comprada_pct)}</span>
-              </div>
-              <div className="flex justify-between">
-                <span className="text-slate-400">Posição Vendida:</span>
-                <span className="font-medium text-white">{formatPercent(portfolio.posicao_vendida_pct)}</span>
-              </div>
-              <div className="flex justify-between">
-                <span className="text-slate-400">Net Long:</span>
-                <span className="font-medium text-white">{formatPercent(portfolio.net_long_pct)}</span>
-              </div>
-              <div className="flex justify-between">
-                <span className="text-slate-400">Exposição Total:</span>
-                <span className="font-medium text-white">{formatPercent(portfolio.exposicao_total_pct)}</span>
+                  </thead>
+                  <tbody>
+                    {holdings.map(h => (
+                      <tr key={h.symbol} className="border-b border-slate-700 hover:bg-slate-700/30">
+                        <td className="px-4 py-3 font-medium text-white whitespace-nowrap">{h.symbol}</td>
+                        <td className="px-4 py-3">{h.quantity}</td>
+                        <td className="px-4 py-3">{formatCurrency(h.avg_price)}</td>
+                        <td className="px-4 py-3">{formatCurrency(h.last_price)}</td>
+                        <td className="px-4 py-3">{formatCurrency(h.position_value)}</td>
+                        <td className={`px-4 py-3 ${h.gain >= 0 ? 'text-green-400' : 'text-red-400'}`}>{formatCurrency(h.gain)}</td>
+                        <td className={`px-4 py-3 ${h.gain >= 0 ? 'text-green-400' : 'text-red-400'}`}>{formatPercent(h.gain_percent)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
               </div>
             </div>
+            <div className="bg-slate-800/50 rounded-lg p-6 border border-slate-700 h-fit">
+              <h2 className="text-xl font-semibold text-white mb-4">Resumo do Portfólio</h2>
+              <div className="space-y-2 text-sm">
+                <div className="flex justify-between">
+                  <span className="text-slate-400">Patrimônio Líquido:</span>
+                  <span className="font-medium text-white">{formatCurrency(portfolio.patrimonio_liquido)}</span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-slate-400">Valor da Cota:</span>
+                  <span className="font-medium text-white">R$ {portfolio.valor_cota.toFixed(2)}</span>
+                </div>
+                <div className={`flex justify-between ${portfolio.variacao_cota_pct >= 0 ? 'text-green-400' : 'text-red-400'}`}>
+                  <span>Variação da Cota:</span>
+                  <span>{formatPercent(portfolio.variacao_cota_pct)}</span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-slate-400">Posição Comprada:</span>
+                  <span className="font-medium text-white">{formatPercent(portfolio.posicao_comprada_pct)}</span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-slate-400">Posição Vendida:</span>
+                  <span className="font-medium text-white">{formatPercent(portfolio.posicao_vendida_pct)}</span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-slate-400">Net Long:</span>
+                  <span className="font-medium text-white">{formatPercent(portfolio.net_long_pct)}</span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-slate-400">Exposição Total:</span>
+                  <span className="font-medium text-white">{formatPercent(portfolio.exposicao_total_pct)}</span>
+                </div>
+              </div>
+            </div>
           </div>
-        </div>
+          <PortfolioCharts />
+        </>
       )}
     </div>
   );

--- a/frontend/services/portfolioApi.ts
+++ b/frontend/services/portfolioApi.ts
@@ -1,4 +1,4 @@
-import { PortfolioSummary, PortfolioDailyValue } from '../types';
+import { PortfolioSummary, PortfolioDailyValue, AssetContribution, IbovHistoryPoint } from '../types';
 
 const API_BASE = import.meta.env.VITE_BACKEND_URL || 'http://localhost:5001/api';
 
@@ -41,6 +41,24 @@ export async function getPortfolioDailyValues(id: number): Promise<PortfolioDail
   return data.values as PortfolioDailyValue[];
 }
 
+export async function getDailyContribution(id: number): Promise<AssetContribution[]> {
+  const res = await fetch(`${API_BASE}/portfolio/${id}/daily-contribution`);
+  if (!res.ok) {
+    throw new Error('Falha ao buscar contribuição diária');
+  }
+  const data = await res.json();
+  return data.contributions as AssetContribution[];
+}
+
+export async function getIbovHistory(): Promise<IbovHistoryPoint[]> {
+  const res = await fetch(`${API_BASE}/market/ibov-history`);
+  if (!res.ok) {
+    throw new Error('Falha ao buscar histórico do Ibovespa');
+  }
+  const data = await res.json();
+  return data.history as IbovHistoryPoint[];
+}
+
 export async function updateDailyMetrics(
   id: number,
   metrics: { id: string; value: number }[],
@@ -59,6 +77,8 @@ export const portfolioApi = {
   savePortfolioSnapshot,
   upsertPositions,
   getPortfolioDailyValues,
+  getDailyContribution,
+  getIbovHistory,
   updateDailyMetrics,
 };
 

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -60,6 +60,16 @@ export interface PortfolioDailyValue {
   total_gain_percent: number;
 }
 
+export interface AssetContribution {
+  symbol: string;
+  contribution: number;
+}
+
+export interface IbovHistoryPoint {
+  date: string;
+  close: number;
+}
+
 export interface ChatMessage {
   role: 'user' | 'model';
   content: string;

--- a/test_market_routes.py
+++ b/test_market_routes.py
@@ -1,0 +1,17 @@
+import pandas as pd
+from datetime import datetime
+
+def test_get_ibov_history(monkeypatch, client):
+    from backend.routes import market_routes
+
+    def fake_download(symbol, start=None, end=None, progress=None):
+        idx = pd.date_range(datetime(2024, 1, 1), periods=3, freq='D')
+        return pd.DataFrame({'Adj Close': [100, 101, 102]}, index=idx)
+
+    monkeypatch.setattr(market_routes, 'yf', type('obj', (), {'download': fake_download}))
+
+    resp = client.get('/api/market/ibov-history')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data['success'] is True
+    assert len(data['history']) == 3


### PR DESCRIPTION
## Summary
- add endpoint for daily contribution per portfolio asset
- expose Ibovespa historical data and frontend API helpers
- render contribution bar and return comparison charts in portfolio dashboard

## Testing
- `npm test`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b74c1d3208327af8c129816555ee6