### PR TITLE
feat: add suggested portfolio and sector weights

### DIFF
--- a/frontend/components/PortfolioDashboard.tsx
+++ b/frontend/components/PortfolioDashboard.tsx
@@ -1,12 +1,16 @@
 import React, { useEffect, useState } from 'react';
 import PortfolioManager from './PortfolioManager';
 import PortfolioCharts from './PortfolioCharts';
-import { PortfolioSummary } from '../types';
+import SuggestedPortfolio from './SuggestedPortfolio';
+import SectorWeights from './SectorWeights';
+import { PortfolioSummary, SuggestedPortfolioAsset, SectorWeight } from '../types';
 import { portfolioApi } from '../services/portfolioApi';
 
 const PortfolioDashboard: React.FC = () => {
   const [portfolio, setPortfolio] = useState<PortfolioSummary | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [suggested, setSuggested] = useState<SuggestedPortfolioAsset[]>([]);
+  const [sectorWeights, setSectorWeights] = useState<SectorWeight[]>([]);
 
   const loadSummary = async () => {
     try {
@@ -18,8 +22,28 @@ const PortfolioDashboard: React.FC = () => {
     }
   };
 
+  const loadSuggested = async () => {
+    try {
+      const data = await portfolioApi.getSuggestedPortfolio(1);
+      setSuggested(data);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const loadSectorWeights = async () => {
+    try {
+      const data = await portfolioApi.getSectorWeights(1);
+      setSectorWeights(data);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
   useEffect(() => {
     loadSummary();
+    loadSuggested();
+    loadSectorWeights();
   }, []);
 
   const holdings = portfolio?.holdings ?? [];
@@ -105,6 +129,10 @@ const PortfolioDashboard: React.FC = () => {
             </div>
           </div>
           <PortfolioCharts />
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+            <SuggestedPortfolio assets={suggested} />
+            <SectorWeights weights={sectorWeights} />
+          </div>
         </>
       )}
     </div>

--- a/frontend/components/SectorWeights.tsx
+++ b/frontend/components/SectorWeights.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { SectorWeight } from '../types';
+
+interface Props {
+  weights: SectorWeight[];
+}
+
+const SectorWeights: React.FC<Props> = ({ weights }) => {
+  const formatPercent = (v: number) => `${v.toFixed(2)}%`;
+
+  return (
+    <div className="bg-slate-800/50 rounded-lg p-6 border border-slate-700">
+      <h2 className="text-xl font-semibold text-white mb-4">Pesos por Setor</h2>
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm text-left text-slate-300">
+          <thead className="text-xs text-slate-400 uppercase bg-slate-700/50">
+            <tr>
+              {['Setor','Peso Ibov','Peso Carteira','OW/UW'].map(h => (
+                <th key={h} className="px-4 py-3 whitespace-nowrap">{h}</th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {weights.map(w => (
+              <tr key={w.sector} className="border-b border-slate-700 hover:bg-slate-700/30">
+                <td className="px-4 py-3 font-medium text-white whitespace-nowrap">{w.sector}</td>
+                <td className="px-4 py-3">{formatPercent(w.ibovWeight)}</td>
+                <td className="px-4 py-3">{formatPercent(w.portfolioWeight)}</td>
+                <td className={`px-4 py-3 ${w.owUw >= 0 ? 'text-green-400' : 'text-red-400'}`}>{formatPercent(w.owUw)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};
+
+export default SectorWeights;

--- a/frontend/components/SuggestedPortfolio.tsx
+++ b/frontend/components/SuggestedPortfolio.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { SuggestedPortfolioAsset } from '../types';
+
+interface Props {
+  assets: SuggestedPortfolioAsset[];
+}
+
+const SuggestedPortfolio: React.FC<Props> = ({ assets }) => {
+  const formatCurrency = (v: number) => `R$ ${v.toFixed(2)}`;
+  const formatPercent = (v: number) => `${v.toFixed(2)}%`;
+
+  return (
+    <div className="bg-slate-800/50 rounded-lg p-6 border border-slate-700">
+      <h2 className="text-xl font-semibold text-white mb-4">Carteira Sugerida</h2>
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm text-left text-slate-300">
+          <thead className="text-xs text-slate-400 uppercase bg-slate-700/50">
+            <tr>
+              {['Ticker','Empresa','Preço Atual','Preço-Alvo','Upside','Peso Ibov','Peso Carteira','OW/UW'].map(h => (
+                <th key={h} className="px-4 py-3 whitespace-nowrap">{h}</th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {assets.map(a => (
+              <tr key={a.ticker} className="border-b border-slate-700 hover:bg-slate-700/30">
+                <td className="px-4 py-3 font-medium text-white whitespace-nowrap">{a.ticker}</td>
+                <td className="px-4 py-3">{a.company}</td>
+                <td className="px-4 py-3">{formatCurrency(a.currentPrice)}</td>
+                <td className="px-4 py-3">{formatCurrency(a.targetPrice)}</td>
+                <td className={`px-4 py-3 ${a.upsideDownside >= 0 ? 'text-green-400' : 'text-red-400'}`}>{formatPercent(a.upsideDownside)}</td>
+                <td className="px-4 py-3">{formatPercent(a.ibovWeight)}</td>
+                <td className="px-4 py-3">{formatPercent(a.portfolioWeight)}</td>
+                <td className={`px-4 py-3 ${a.owUw >= 0 ? 'text-green-400' : 'text-red-400'}`}>{formatPercent(a.owUw)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};
+
+export default SuggestedPortfolio;

--- a/frontend/services/portfolioApi.ts
+++ b/frontend/services/portfolioApi.ts
@@ -1,4 +1,11 @@
-import { PortfolioSummary, PortfolioDailyValue, AssetContribution, IbovHistoryPoint } from '../types';
+import {
+  PortfolioSummary,
+  PortfolioDailyValue,
+  AssetContribution,
+  IbovHistoryPoint,
+  SuggestedPortfolioAsset,
+  SectorWeight,
+} from '../types';
 
 const API_BASE = import.meta.env.VITE_BACKEND_URL || 'http://localhost:5001/api';
 
@@ -50,6 +57,24 @@ export async function getDailyContribution(id: number): Promise<AssetContributio
   return data.contributions as AssetContribution[];
 }
 
+export async function getSuggestedPortfolio(id: number): Promise<SuggestedPortfolioAsset[]> {
+  const res = await fetch(`${API_BASE}/portfolio/${id}/suggested`);
+  if (!res.ok) {
+    throw new Error('Falha ao buscar carteira sugerida');
+  }
+  const data = await res.json();
+  return data.assets as SuggestedPortfolioAsset[];
+}
+
+export async function getSectorWeights(id: number): Promise<SectorWeight[]> {
+  const res = await fetch(`${API_BASE}/portfolio/${id}/sector-weights`);
+  if (!res.ok) {
+    throw new Error('Falha ao buscar pesos por setor');
+  }
+  const data = await res.json();
+  return data.weights as SectorWeight[];
+}
+
 export async function getIbovHistory(): Promise<IbovHistoryPoint[]> {
   const res = await fetch(`${API_BASE}/market/ibov-history`);
   if (!res.ok) {
@@ -80,5 +105,7 @@ export const portfolioApi = {
   getDailyContribution,
   getIbovHistory,
   updateDailyMetrics,
+  getSuggestedPortfolio,
+  getSectorWeights,
 };
 

--- a/test_portfolio_routes.py
+++ b/test_portfolio_routes.py
@@ -74,3 +74,48 @@ def test_get_daily_contribution_returns_data(client):
     assert data["contributions"][0]["contribution"] == 2
 
 
+def test_get_suggested_portfolio_returns_data(client):
+    with client.application.app_context():
+        company = Company(id=1, company_name="Vale")
+        ticker = Ticker(symbol="VALE3", company_id=1, type="stock")
+        portfolio = Portfolio(id=1, name="P1")
+        pos = PortfolioPosition(portfolio_id=1, symbol="VALE3", quantity=10, avg_price=5)
+        metric = AssetMetrics(
+            symbol="VALE3", last_price=10, price_change_percent=0, sector="Materials"
+        )
+        db.session.add_all([company, ticker, portfolio, pos, metric])
+        db.session.commit()
+
+    resp = client.get("/api/portfolio/1/suggested")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["success"] is True
+    assert len(data["assets"]) == 1
+    asset = data["assets"][0]
+    assert asset["ticker"] == "VALE3"
+    assert asset["currentPrice"] == 10
+    assert round(asset["portfolioWeight"], 2) == 100.0
+
+
+def test_get_sector_weights_returns_data(client):
+    with client.application.app_context():
+        company = Company(id=1, company_name="Vale")
+        ticker = Ticker(symbol="VALE3", company_id=1, type="stock")
+        portfolio = Portfolio(id=1, name="P1")
+        pos = PortfolioPosition(portfolio_id=1, symbol="VALE3", quantity=10, avg_price=5)
+        metric = AssetMetrics(
+            symbol="VALE3", last_price=10, price_change_percent=0, sector="Materials"
+        )
+        db.session.add_all([company, ticker, portfolio, pos, metric])
+        db.session.commit()
+
+    resp = client.get("/api/portfolio/1/sector-weights")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["success"] is True
+    assert len(data["weights"]) == 1
+    weight = data["weights"][0]
+    assert weight["sector"] == "Materials"
+    assert round(weight["portfolioWeight"], 2) == 100.0
+
+


### PR DESCRIPTION
## Summary
- add backend routes to fetch portfolio suggestions and sector weights
- expose new portfolio API services and UI components
- integrate suggested assets and sector weights into portfolio dashboard
- test suggested portfolio and sector weights endpoints

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b776e87048327b523a1b99f66a68b