### PR TITLE
Handle timestamp for market news dates

### DIFF
--- a/frontend/components/MarketNews.tsx
+++ b/frontend/components/MarketNews.tsx
@@ -94,7 +94,7 @@ const MarketNews: React.FC = () => {
                             <p className="text-xs text-slate-400 mt-1">{news.summary}</p>
                             <div className="flex items-center justify-between mt-1.5">
                                 <span className="text-xs text-slate-400">{news.source.toUpperCase()}</span>
-                                <span className="text-xs text-slate-500">{new Date(news.collectedAt).toLocaleDateString()}</span>
+                                <span className="text-xs text-slate-500">{new Date(news.timestamp || news.collectedAt).toLocaleDateString()}</span>
                             </div>
                         </div>
                     ))}
@@ -117,7 +117,7 @@ const MarketNews: React.FC = () => {
                         <div className="flex justify-between items-start mb-4">
                             <div>
                                 <h1 className="text-2xl font-bold text-white">{selectedArticle.title}</h1>
-                                <p className="text-sm text-slate-400 mt-1">{new Date(selectedArticle.collectedAt).toLocaleDateString()} • {selectedArticle.source}</p>
+                                <p className="text-sm text-slate-400 mt-1">{new Date(selectedArticle.timestamp || selectedArticle.collectedAt).toLocaleDateString()} • {selectedArticle.source}</p>
                             </div>
                             <button onClick={() => setSelectedArticle(newsArticles[0] || null)} className="p-1 text-slate-400 hover:text-white rounded-full hover:bg-slate-700">
                                 <XMarkIcon className="w-5 h-5"/>

--- a/frontend/services/newsService.ts
+++ b/frontend/services/newsService.ts
@@ -41,7 +41,8 @@ export const getLatestNews = async (
     id: Number(item.id ?? idx),
     title: item.titulo,
     source: item.portal,
-    collectedAt: item.data_coleta,
+    collectedAt: item.data_coleta || item.timestamp,
+    timestamp: item.timestamp || item.data_coleta,
     summary: item.resumo,
     content:
       item.conteudo_completo ||

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -101,7 +101,8 @@ export interface MarketNewsArticle {
     id: number;
     title: string;
     source: string;
-    collectedAt: string;
+    collectedAt?: string;
+    timestamp?: string | number;
     summary: string;
     content: string;
     url: string;


### PR DESCRIPTION
## Summary
- allow MarketNews to format dates from either `timestamp` or `collectedAt`
- map `timestamp` field in news service and types

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b79c6b2ac832797b6338326275692