### PR TITLE
Include detailed CVM API error messages

### DIFF
--- a/frontend/components/CvmDocuments.tsx
+++ b/frontend/components/CvmDocuments.tsx
@@ -87,7 +87,7 @@ const CvmDocuments: React.FC = () => {
                 setCompanies([{ value: '', label: 'Todas' }, ...companyData.map(c => ({ value: String(c.id), label: `${c.ticker} - ${c.company_name}` }))]);
             } catch (e: any) {
                 setCompanies([{ value: '', label: 'Todas' }]);
-                setError(e?.message || 'Erro ao carregar empresas');
+                setError(e?.message ?? 'Erro ao carregar empresas');
             }
 
             try {
@@ -95,7 +95,7 @@ const CvmDocuments: React.FC = () => {
                 setDocumentTypes([{ value: '', label: 'Todas' }, ...docTypes.map(dt => ({ value: dt.code, label: dt.name }))]);
             } catch (e: any) {
                 setDocumentTypes([{ value: '', label: 'Todas' }]);
-                setError(e?.message || 'Erro ao carregar tipos de documento');
+                setError(e?.message ?? 'Erro ao carregar tipos de documento');
             }
         };
         loadFilters();
@@ -143,7 +143,7 @@ const CvmDocuments: React.FC = () => {
             setDocuments(docs);
         } catch (e: any) {
             setDocuments([]);
-            setError(e?.message || 'Erro ao carregar documentos');
+            setError(e?.message ?? 'Erro ao carregar documentos');
         } finally {
             setLoading(false);
         }

--- a/frontend/services/cvmService.test.ts
+++ b/frontend/services/cvmService.test.ts
@@ -22,6 +22,14 @@ describe('cvmService', () => {
     await expect(cvmService.getCompanies()).rejects.toThrow('Erro ao buscar empresas');
   });
 
+  it('getCompanies inclui mensagem detalhada do backend', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      json: async () => ({ message: 'Detalhe' })
+    }));
+    await expect(cvmService.getCompanies()).rejects.toThrow('Erro ao buscar empresas: Detalhe');
+  });
+
   it('getDocumentTypes retorna lista de categorias', async () => {
     const mockTypes = ['CAT'];
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
@@ -49,6 +57,14 @@ describe('cvmService', () => {
   it('getDocumentTypes lança erro quando resposta não ok', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false }));
     await expect(cvmService.getDocumentTypes()).rejects.toThrow('Erro ao buscar tipos de documento');
+  });
+
+  it('getDocumentTypes inclui mensagem detalhada do backend', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      json: async () => ({ error: 'Problema' })
+    }));
+    await expect(cvmService.getDocumentTypes()).rejects.toThrow('Erro ao buscar tipos de documento: Problema');
   });
 
   it('getDocuments usa endpoint por empresa quando companyId informado', async () => {
@@ -83,5 +99,13 @@ describe('cvmService', () => {
   it('getDocuments lança erro quando resposta não ok', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false }));
     await expect(cvmService.getDocuments()).rejects.toThrow('Erro ao buscar documentos');
+  });
+
+  it('getDocuments inclui mensagem detalhada do backend', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      json: async () => ({ message: 'Falhou' })
+    }));
+    await expect(cvmService.getDocuments()).rejects.toThrow('Erro ao buscar documentos: Falhou');
   });
 });


### PR DESCRIPTION
## Summary
- propagate backend error details in CVM service calls
- surface detailed CVM fetch errors in CvmDocuments component
- add tests for error message propagation

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b79ebb6c88327a0e4aa7aefac533b