### PR TITLE
Preserve news timestamps with full precision

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -192,7 +192,12 @@ class MarketArticle(db.Model):
     score_impacto = db.Column(Numeric(10, 4))
 
     def to_dict(self):
-        return {c.name: getattr(self, c.name) for c in self.__table__.columns}
+        data = {c.name: getattr(self, c.name) for c in self.__table__.columns}
+        if data.get('data_coleta'):
+            data['data_coleta'] = data['data_coleta'].isoformat()
+        if data.get('data_publicacao'):
+            data['data_publicacao'] = data['data_publicacao'].isoformat()
+        return data
 
 
 class Portfolio(db.Model):

--- a/backend/routes/news_routes.py
+++ b/backend/routes/news_routes.py
@@ -30,11 +30,8 @@ def get_latest_news():
     if portal:
         query = query.filter(MarketArticle.portal == portal)
 
-    order_clause = (
-        MarketArticle.data_coleta.asc()
-        if order == 'asc'
-        else MarketArticle.data_coleta.desc()
-    )
+    order_field = MarketArticle.data_coleta
+    order_clause = order_field.asc() if order == 'asc' else order_field.desc()
     articles = query.order_by(order_clause).limit(limit).all()
     return jsonify([a.to_dict() for a in articles])
 

--- a/frontend/components/MarketNews.tsx
+++ b/frontend/components/MarketNews.tsx
@@ -94,7 +94,7 @@ const MarketNews: React.FC = () => {
                             <p className="text-xs text-slate-400 mt-1">{news.summary}</p>
                             <div className="flex items-center justify-between mt-1.5">
                                 <span className="text-xs text-slate-400">{news.source.toUpperCase()}</span>
-                                <span className="text-xs text-slate-500">{new Date(news.timestamp || news.collectedAt).toLocaleDateString()}</span>
+                                <span className="text-xs text-slate-500">{new Date(news.timestamp || news.collectedAt).toLocaleString('pt-BR', { dateStyle: 'short', timeStyle: 'short' })}</span>
                             </div>
                         </div>
                     ))}
@@ -117,7 +117,7 @@ const MarketNews: React.FC = () => {
                         <div className="flex justify-between items-start mb-4">
                             <div>
                                 <h1 className="text-2xl font-bold text-white">{selectedArticle.title}</h1>
-                                <p className="text-sm text-slate-400 mt-1">{new Date(selectedArticle.timestamp || selectedArticle.collectedAt).toLocaleDateString()} • {selectedArticle.source}</p>
+                                <p className="text-sm text-slate-400 mt-1">{new Date(selectedArticle.timestamp || selectedArticle.collectedAt).toLocaleString('pt-BR', { dateStyle: 'short', timeStyle: 'short' })} • {selectedArticle.source}</p>
                             </div>
                             <button onClick={() => setSelectedArticle(newsArticles[0] || null)} className="p-1 text-slate-400 hover:text-white rounded-full hover:bg-slate-700">
                                 <XMarkIcon className="w-5 h-5"/>

--- a/frontend/services/newsService.ts
+++ b/frontend/services/newsService.ts
@@ -37,23 +37,27 @@ export const getLatestNews = async (
   }
   const json = await res.json();
   const items = (json.news || json.data || json) as any[];
-  return items.map((item: any, idx: number) => ({
-    id: Number(item.id ?? idx),
-    title: item.titulo,
-    source: item.portal,
-    collectedAt: item.data_coleta || item.timestamp,
-    timestamp: item.timestamp || item.data_coleta,
-    summary: item.resumo,
-    content:
-      item.conteudo_completo ||
-      item.conteudo ||
-      item.content ||
-      item.resumo,
-    url: item.link_url,
-    imageUrl: item.imagem_url || item.image_url,
-    tags: item.tags,
-    aiAnalysis: item.aiAnalysis,
-  }));
+  return items.map((item: any, idx: number) => {
+    const collectedAt = item.data_coleta;
+    const timestamp = collectedAt ? new Date(collectedAt).toISOString() : undefined;
+    return {
+      id: Number(item.id ?? idx),
+      title: item.titulo,
+      source: item.portal,
+      collectedAt,
+      timestamp,
+      summary: item.resumo,
+      content:
+        item.conteudo_completo ||
+        item.conteudo ||
+        item.content ||
+        item.resumo,
+      url: item.link_url,
+      imageUrl: item.imagem_url || item.image_url,
+      tags: item.tags,
+      aiAnalysis: item.aiAnalysis,
+    };
+  });
 };
 
 export const analyzeNews = async (

--- a/test_news_routes.py
+++ b/test_news_routes.py
@@ -6,18 +6,18 @@ from backend.models import MarketArticle
 
 @pytest.fixture
 def news_with_dates(client):
-    """Insere duas notícias com datas de coleta distintas."""
+    """Insere duas notícias com horários de coleta distintos."""
     with client.application.app_context():
         older = MarketArticle(
             titulo='Old',
             portal='PortalA',
-            data_coleta=datetime(2024, 1, 1),
+            data_coleta=datetime(2024, 1, 1, 9, 0, 0),
             tickers_relacionados=[],
         )
         newer = MarketArticle(
             titulo='New',
             portal='PortalB',
-            data_coleta=datetime(2024, 1, 2),
+            data_coleta=datetime(2024, 1, 1, 15, 30, 0),
             tickers_relacionados=[],
         )
         db.session.add_all([older, newer])
@@ -65,10 +65,7 @@ def test_get_latest_news_ordering(client, news_with_dates, order):
     resp = client.get(f'/api/news/latest?order={order}')
     assert resp.status_code == 200
     data = resp.get_json()
-    data_coletas = [
-        datetime.strptime(item['data_coleta'], '%a, %d %b %Y %H:%M:%S GMT')
-        for item in data
-    ]
+    data_coletas = [datetime.fromisoformat(item['data_coleta']) for item in data]
     expected = [older_dt, newer_dt] if order == 'asc' else [newer_dt, older_dt]
     assert data_coletas == expected
 


### PR DESCRIPTION
## Summary
- Ensure latest news endpoint orders by full `data_coleta` timestamp and serialize collection and publication dates in ISO format.
- Map backend `data_coleta` to ISO timestamps in the frontend service for accurate time handling and display dates with time in market news component.
- Expand news route tests with distinct collection times and ISO parsing to validate hour-level ordering.

## Testing
- `npm test`
- `pytest test_news_routes.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689b9159df648327a3aa4e953de52bd6