### PR TITLE
Simplify ticker lookup in upsert_positions

### DIFF
--- a/backend/routes/portfolio_routes.py
+++ b/backend/routes/portfolio_routes.py
@@ -175,9 +175,7 @@ def upsert_positions(portfolio_id: int):
             symbol = item.get("symbol")
             if not symbol:
                 continue
-            ticker = Ticker.query.get(symbol)
-            if not ticker:
-                ticker = Ticker.query.filter_by(symbol=symbol).first()
+            ticker = Ticker.query.filter_by(symbol=symbol).first()
             if not ticker:
                 ticker_type = item.get("type")
                 if not ticker_type:


### PR DESCRIPTION
## Summary
- Use a single `filter_by` call to fetch tickers by symbol when upserting portfolio positions

## Testing
- `pytest test_portfolio_routes.py::test_upsert_positions_requires_type_for_new_ticker test_portfolio_routes.py::test_upsert_positions_creates_ticker_and_position_when_type_provided test_portfolio_routes.py::test_upsert_positions_inserts_when_ticker_exists -q`


------
https://chatgpt.com/codex/tasks/task_e_689b9494b0f483278807033899183818