### PR TITLE
Handle missing portfolio metrics safely

### DIFF
--- a/backend/routes/portfolio_routes.py
+++ b/backend/routes/portfolio_routes.py
@@ -40,9 +40,15 @@ def calculate_portfolio_summary(portfolio_id: int):
     total_long = 0.0
     total_short = 0.0
     for pos in positions:
-        last_price = float(pos.metrics.last_price) if pos.metrics else 0.0
+        last_price = (
+            float(pos.metrics.last_price)
+            if pos.metrics and pos.metrics.last_price is not None
+            else 0.0
+        )
         daily_change_pct = (
-            float(pos.metrics.price_change_percent) if pos.metrics else 0.0
+            float(pos.metrics.price_change_percent)
+            if pos.metrics and pos.metrics.price_change_percent is not None
+            else 0.0
         )
         quantity = float(pos.quantity)
         avg_price = float(pos.avg_price)
@@ -96,10 +102,10 @@ def calculate_portfolio_summary(portfolio_id: int):
 
     today = date.today()
     metrics = {
-        m.metric_id: float(m.value)
+        m.metric_id: float(m.value) if m.value is not None else 0.0
         for m in PortfolioDailyMetric.query.filter_by(
             portfolio_id=portfolio_id, date=today
-        ).all()
+        )
     }
     qtd_cotas = metrics.get("qtdCotas", 0.0)
     cota_d1 = metrics.get("cotaD1")


### PR DESCRIPTION
## Summary
- protect portfolio summary calculations from `None` last price and price change percent values
- default portfolio daily metric values to zero when undefined

## Testing
- `pytest test_portfolio_routes.py`
- python snippet hitting `/summary`, `/suggested`, `/sector-weights` and `/positions`

------
https://chatgpt.com/codex/tasks/task_e_689b9e4b5ea08327a0e351045751a4f7