### PR TITLE
Allow empty research note content

### DIFF
--- a/backend/routes/research_routes.py
+++ b/backend/routes/research_routes.py
@@ -32,8 +32,8 @@ def create_note():
     data = request.get_json(silent=True) or {}
     title = data.get('title')
     summary = data.get('summary', '')
-    content = data.get('content')
-    if not title or not content:
+    content = data.get('content', '')
+    if not title or content is None:
         return jsonify({'success': False, 'error': 'Campos obrigatórios não fornecidos'}), 400
     try:
         note = ResearchNote(title=title, summary=summary, content=content)

--- a/test_research_routes.py
+++ b/test_research_routes.py
@@ -34,6 +34,6 @@ def test_research_notes_crud(client):
     assert resp.status_code == 200
     assert resp.get_json()['notes'] == []
 
-def test_create_note_without_content(client):
-    resp = client.post('/api/research/notes', json={'title': 'Only title'})
+def test_create_note_with_null_content(client):
+    resp = client.post('/api/research/notes', json={'title': 'Only title', 'content': None})
     assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- Permit creating research notes with empty content by defaulting missing `content` field to an empty string and only rejecting `None` values.
- Adjust research note tests to validate that null content is still rejected.

## Testing
- `curl -i -X POST http://127.0.0.1:5001/api/research/notes -H 'Content-Type: application/json' -d '{"title": "My Note", "content": ""}'`
- `pytest test_research_routes.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689ba7e67604832788fd9be49cf740c8