### PR TITLE
Add portfolio daily metrics migration

### DIFF
--- a/migrations/versions/0f54de82af65_rename_category_column.py
+++ b/migrations/versions/0f54de82af65_rename_category_column.py
@@ -22,19 +22,32 @@ def upgrade() -> None:
     """Upgrade schema by renaming or adding column."""
     bind = op.get_bind()
     inspector = sa.inspect(bind)
-    columns = [c["name"] for c in inspector.get_columns("cvm_documents")]
+    try:
+        columns = [c["name"] for c in inspector.get_columns("cvm_documents")]
+    except sa.exc.NoSuchTableError:
+        return
     if "category" in columns:
-        op.alter_column("cvm_documents", "category", new_column_name="document_category")
+        op.alter_column(
+            "cvm_documents", "category", new_column_name="document_category"
+        )
     elif "document_category" not in columns:
-        op.add_column("cvm_documents", sa.Column("document_category", sa.String(), nullable=True))
+        op.add_column(
+            "cvm_documents",
+            sa.Column("document_category", sa.String(), nullable=True),
+        )
 
 
 def downgrade() -> None:
     """Revert schema changes."""
     bind = op.get_bind()
     inspector = sa.inspect(bind)
-    columns = [c["name"] for c in inspector.get_columns("cvm_documents")]
+    try:
+        columns = [c["name"] for c in inspector.get_columns("cvm_documents")]
+    except sa.exc.NoSuchTableError:
+        return
     if "document_category" in columns and "category" not in columns:
-        op.alter_column("cvm_documents", "document_category", new_column_name="category")
+        op.alter_column(
+            "cvm_documents", "document_category", new_column_name="category"
+        )
     elif "document_category" in columns:
         op.drop_column("cvm_documents", "document_category")

--- a/migrations/versions/3bba235f3ec0_add_data_coleta_to_marketarticle.py
+++ b/migrations/versions/3bba235f3ec0_add_data_coleta_to_marketarticle.py
@@ -20,9 +20,17 @@ depends_on: Union[str, Sequence[str], None] = None
 
 def upgrade() -> None:
     """Upgrade schema."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if 'artigos_mercado' not in inspector.get_table_names():
+        return
     op.add_column('artigos_mercado', sa.Column('data_coleta', sa.DateTime(), nullable=True))
 
 
 def downgrade() -> None:
     """Downgrade schema."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if 'artigos_mercado' not in inspector.get_table_names():
+        return
     op.drop_column('artigos_mercado', 'data_coleta')

--- a/migrations/versions/41040a87193c_add_portfolio_daily_metrics.py
+++ b/migrations/versions/41040a87193c_add_portfolio_daily_metrics.py
@@ -1,0 +1,86 @@
+"""add portfolio daily metrics
+
+Revision ID: 41040a87193c
+Revises: 3bba235f3ec0
+Create Date: 2025-08-12 20:52:00.291975
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "41040a87193c"
+down_revision: Union[str, Sequence[str], None] = "3bba235f3ec0"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "portfolios",
+        sa.Column("id", sa.Integer(), primary_key=True, nullable=False),
+        sa.Column("name", sa.String(length=100), nullable=False),
+    )
+    op.create_table(
+        "portfolio_daily_metrics",
+        sa.Column("id", sa.Integer(), primary_key=True, nullable=False),
+        sa.Column("portfolio_id", sa.Integer(), nullable=False),
+        sa.Column("metric_id", sa.String(length=100), nullable=False),
+        sa.Column("value", sa.Numeric(20, 4), nullable=False),
+        sa.Column(
+            "date", sa.Date(), nullable=False, server_default=sa.text("(CURRENT_DATE)")
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("(CURRENT_TIMESTAMP)"),
+            nullable=True,
+        ),
+        sa.ForeignKeyConstraint(["portfolio_id"], ["portfolios.id"]),
+        sa.UniqueConstraint(
+            "portfolio_id", "metric_id", "date", name="uix_portfolio_metric_date"
+        ),
+    )
+    op.create_index(
+        "ix_portfolio_daily_metrics_portfolio_id",
+        "portfolio_daily_metrics",
+        ["portfolio_id"],
+    )
+    op.create_table(
+        "portfolio_daily_values",
+        sa.Column("id", sa.Integer(), primary_key=True, nullable=False),
+        sa.Column("portfolio_id", sa.Integer(), nullable=False),
+        sa.Column(
+            "date", sa.Date(), nullable=False, server_default=sa.text("(CURRENT_DATE)")
+        ),
+        sa.Column("total_value", sa.Numeric(20, 2), nullable=False),
+        sa.Column("total_cost", sa.Numeric(20, 2), nullable=False),
+        sa.Column("total_gain", sa.Numeric(20, 2), nullable=False),
+        sa.Column("total_gain_percent", sa.Numeric(10, 4), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("(CURRENT_TIMESTAMP)"),
+            nullable=True,
+        ),
+        sa.ForeignKeyConstraint(["portfolio_id"], ["portfolios.id"]),
+        sa.UniqueConstraint("portfolio_id", "date", name="uix_portfolio_date"),
+    )
+    op.create_index(
+        "ix_portfolio_daily_values_portfolio_id",
+        "portfolio_daily_values",
+        ["portfolio_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_portfolio_daily_values_portfolio_id", table_name="portfolio_daily_values"
+    )
+    op.drop_table("portfolio_daily_values")
+    op.drop_index(
+        "ix_portfolio_daily_metrics_portfolio_id", table_name="portfolio_daily_metrics"
+    )
+    op.drop_table("portfolio_daily_metrics")
+    op.drop_table("portfolios")

--- a/migrations/versions/5a6c7d8e9f10_make_ticker_company_id_nullable.py
+++ b/migrations/versions/5a6c7d8e9f10_make_ticker_company_id_nullable.py
@@ -16,8 +16,24 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    op.alter_column('tickers', 'company_id', existing_type=sa.Integer(), nullable=True)
+    """Make company_id nullable in a SQLite-compatible way."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if "tickers" not in inspector.get_table_names():
+        return
+    with op.batch_alter_table("tickers") as batch_op:
+        batch_op.alter_column(
+            "company_id", existing_type=sa.Integer(), nullable=True
+        )
 
 
 def downgrade() -> None:
-    op.alter_column('tickers', 'company_id', existing_type=sa.Integer(), nullable=False)
+    """Revert company_id back to non-nullable."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if "tickers" not in inspector.get_table_names():
+        return
+    with op.batch_alter_table("tickers") as batch_op:
+        batch_op.alter_column(
+            "company_id", existing_type=sa.Integer(), nullable=False
+        )


### PR DESCRIPTION
## Summary
- add migration creating `portfolios`, `portfolio_daily_metrics`, and `portfolio_daily_values` tables
- make existing migrations resilient to missing tables and SQLite limitations

## Testing
- `alembic upgrade head`
- `pytest test_portfolio_routes.py::test_update_daily_metrics_inserts_values -q`
- `curl -s -o /dev/null -w "%{http_code}\n" http://127.0.0.1:5001/api/portfolio/1/summary`
- `curl -s -o /dev/null -w "%{http_code}\n" -X POST -H "Content-Type: application/json" -d '[{"id":"m1","value":1.23}]' http://127.0.0.1:5001/api/portfolio/1/daily-metrics`


------
https://chatgpt.com/codex/tasks/task_e_689ba847d370832783ef016785e4650d