### PR TITLE
chore: enforce postgres config for migrations

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -81,10 +81,11 @@ path_separator = os
 # are written from script.py.mako
 # output_encoding = utf-8
 
-# database URL.  This is consumed by the user-maintained env.py script only.
-# other means of configuring database URLs may be customized within the env.py
-# file.
-sqlalchemy.url = sqlite:///app.db
+# database URL.  This value is overridden in migrations/env.py using the
+# configuration provided by environment variables. It is defined here to mirror
+# the structure of the production database and avoid falling back to SQLite.
+# Example: postgresql+psycopg2://user:password@host:5432/dbname
+sqlalchemy.url = postgresql+psycopg2://${DB_USER}:${DB_PASSWORD}@${DB_HOST}/${DB_NAME}
 
 
 [post_write_hooks]

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -15,13 +15,23 @@ from backend.models import db
 # access to the values within the .ini file in use.
 config = context.config
 db_url = Config.SQLALCHEMY_DATABASE_URI
-if not all([Config.DB_USER, Config.DB_PASSWORD, Config.DB_HOST, Config.DB_NAME]):
-    db_url = "sqlite:///app.db"
+
+# Ensure all required database settings are provided to avoid falling back
+# to SQLite. This makes migration configuration explicit and prevents
+# accidental use of a local file database when environment variables are
+# missing.
+required_settings = [Config.DB_USER, Config.DB_PASSWORD, Config.DB_HOST, Config.DB_NAME]
+if not all(required_settings):
+    raise RuntimeError(
+        "Missing database configuration. Set DB_USER, DB_PASSWORD, "
+        "DB_HOST and DB_NAME before running migrations."
+    )
+
 config.set_main_option("sqlalchemy.url", db_url)
 
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.
-if config.config_file_name is not None:
+if config.config_file_name and os.path.exists(config.config_file_name):
     fileConfig(config.config_file_name)
 
 # add your model's MetaData object here


### PR DESCRIPTION
## Summary
- require explicit DB credentials in Alembic env to avoid SQLite fallback
- reference Postgres connection details in alembic.ini for migrations

## Testing
- `flask db upgrade`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689bacd7fad48327bed90da73a39d87f