### PR TITLE
Improve daily metrics error handling

### DIFF
--- a/backend/routes/portfolio_routes.py
+++ b/backend/routes/portfolio_routes.py
@@ -313,9 +313,15 @@ def update_daily_metrics(portfolio_id: int):
         return jsonify({"success": True}), 201
     except Exception as e:
         db.session.rollback()
-        logger.error(f"Erro ao salvar métricas: {e}")
+        logger.error("Erro ao salvar métricas", exc_info=True)
         return (
-            jsonify({"success": False, "error": "Erro ao salvar métricas"}),
+            jsonify(
+                {
+                    "success": False,
+                    "error": "Erro ao salvar métricas",
+                    "detail": str(e),
+                }
+            ),
             500,
         )
 


### PR DESCRIPTION
## Summary
- log stack traces on errors updating portfolio daily metrics
- return error details in JSON when daily metrics update fails

## Testing
- `pytest test_portfolio_routes.py::test_update_daily_metrics_inserts_values -q`


------
https://chatgpt.com/codex/tasks/task_e_689bb2be29b48327963cab00dc6d9e2a