### PR TITLE
refactor: clean up CVM date range inputs

### DIFF
--- a/frontend/components/CvmDocuments.tsx
+++ b/frontend/components/CvmDocuments.tsx
@@ -123,7 +123,6 @@ const CvmDocuments: React.FC = () => {
                                 placeholder="YYYY-MM-DD"
                                 className="w-full bg-slate-700 border border-slate-600 rounded-md py-2 px-3 text-slate-200 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:border-sky-500"
                             />
-                            <span className="text-slate-400 self-center">até</span>
                             <input
                                 type="date"
                                 value={endDate}


### PR DESCRIPTION
## Summary
- remove leftover date range text and keep only two date fields

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689bb304cef0832793703dc5136c357e