### PR TITLE
Validate portfolio exists before updating daily metrics

### DIFF
--- a/backend/routes/portfolio_routes.py
+++ b/backend/routes/portfolio_routes.py
@@ -283,8 +283,10 @@ def update_daily_metrics(portfolio_id: int):
     try:
         portfolio = Portfolio.query.get(portfolio_id)
         if not portfolio:
-            portfolio = Portfolio(id=portfolio_id, name=f"Portfolio {portfolio_id}")
-            db.session.add(portfolio)
+            return (
+                jsonify({"success": False, "error": "Portfólio não encontrado"}),
+                404,
+            )
 
         today = date.today()
         for item in data:

--- a/test_portfolio_routes.py
+++ b/test_portfolio_routes.py
@@ -43,6 +43,11 @@ def test_upsert_positions_inserts_when_ticker_exists(client):
 
 
 def test_update_daily_metrics_inserts_values(client):
+    with client.application.app_context():
+        portfolio = Portfolio(id=1, name="P1")
+        db.session.add(portfolio)
+        db.session.commit()
+
     payload = [{"id": "cotaD1", "value": 100.5}, {"id": "qtdCotas", "value": 10}]
     resp = client.post("/api/portfolio/1/daily-metrics", json=payload)
     assert resp.status_code == 201
@@ -53,6 +58,13 @@ def test_update_daily_metrics_inserts_values(client):
         assert len(metrics) == 2
         ids = {m.metric_id for m in metrics}
         assert {"cotaD1", "qtdCotas"} == ids
+
+
+def test_update_daily_metrics_returns_404_when_portfolio_not_found(client):
+    payload = [{"id": "cotaD1", "value": 100.5}]
+    resp = client.post("/api/portfolio/99/daily-metrics", json=payload)
+    assert resp.status_code == 404
+    assert resp.get_json()["error"] == "Portfólio não encontrado"
 
 
 def test_get_daily_contribution_returns_data(client):


### PR DESCRIPTION
## Summary
- Require existing portfolio when posting daily metrics
- Add tests for missing portfolio errors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689bb4377d208327ba4af46ed4f35625